### PR TITLE
NuGet install script throws error

### DIFF
--- a/NuGet/install.ps1
+++ b/NuGet/install.ps1
@@ -1,22 +1,47 @@
 ﻿param($installPath, $toolsPath, $package, $project)
-$addinName = "PropertyChanged"
 
-$fodyWeaversPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($project.FullName), "FodyWeavers.xml")
 
-if (!(Test-Path ($fodyWeaversPath)))
+function Update-FodyConfig($addinName, $project)
 {
-	Throw "Could not find FodyWeavers.xml in this project. Please enable Fody for this projet http://visualstudiogallery.msdn.microsoft.com/074a2a26-d034-46f1-8fe1-0da97265eb7a"
-}	
+    $fodyWeaversPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($project.FullName), "FodyWeavers.xml")
 
-$xml = [xml](get-content $fodyWeaversPath)
+    if (!(Test-Path ($fodyWeaversPath)))
+    {
+        Throw "Could not find FodyWeavers.xml in this project. Please enable Fody for this projet http://visualstudiogallery.msdn.microsoft.com/074a2a26-d034-46f1-8fe1-0da97265eb7a"
+    }   
 
-$weavers = $xml["Weavers"]
-$node = $xml.Weavers[$addinName]
+    $xml = [xml](get-content $fodyWeaversPath)
 
-if ($node -eq $null)
-{
-    $newNode = $xml.CreateElement($addinName)
-    $weavers.AppendChild($newNode)
+    $weavers = $xml["Weavers"]
+    $node = $weavers.SelectSingleNode($addinName)
+
+    if (-not $node)
+    {
+        $newNode = $xml.CreateElement($addinName)
+        $weavers.AppendChild($newNode)
+    }
+
+    $xml.Save($fodyWeaversPath)
 }
 
-$xml.Save($fodyWeaversPath)
+function Fix-ReferencesCopyLocal($package, $project)
+{
+    $asms = $package.AssemblyReferences | %{$_.Name}
+
+    foreach ($reference in $project.Object.References)
+    {
+        if ($asms -contains $reference.Name + ".dll")
+        {
+            if($reference.CopyLocal -eq $true)
+            {
+                $reference.CopyLocal = $false;
+            }
+        }
+    }
+}
+
+
+
+Update-FodyConfig "PropertyChanged" $project
+
+Fix-ReferencesCopyLocal $package $project

--- a/NuGet/uninstall.ps1
+++ b/NuGet/uninstall.ps1
@@ -1,23 +1,28 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$addinName = "PropertyChanged"
 
-$fodyWeaversPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($project.FullName), "FodyWeavers.xml")
-
-if (!(Test-Path ($fodyWeaversPath)))
+function Update-FodyConfig($addinName, $project)
 {
-	exit
-}	
+    $fodyWeaversPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($project.FullName), "FodyWeavers.xml")
 
-$xml = [xml](get-content $fodyWeaversPath)
+    if (!(Test-Path ($fodyWeaversPath)))
+    {
+        return
+    }   
 
-$weavers = $xml["Weavers"]
-$node = $xml.Weavers[$addinName]
+    $xml = [xml](get-content $fodyWeaversPath)
 
-if ($node -ne $null)
-{
-    $weavers.RemoveChild($node)
+    $weavers = $xml["Weavers"]
+    $node = $weavers.SelectSingleNode($addinName)
+
+    if ($node)
+    {
+        $weavers.RemoveChild($node)
+    }
+
+    $xml.Save($fodyWeaversPath)
 }
 
-$xml.Save($fodyWeaversPath)
 
+
+Update-FodyConfig "PropertyChanged" $project


### PR DESCRIPTION
When installing from NuGet, if the `FodyWeaver.xml` does not contain a reference to `PropertyChanged` I get the following error.

```
PM> Install-Package PropertyChanged.Fody
Successfully installed 'PropertyChanged.Fody 1.33.0.0'.
Successfully added 'PropertyChanged.Fody 1.33.0.0' to ClassLibrary1.
Cannot convert value "PropertyChanged" to type "System.Int32". Error: "Input string was not in a correct format."
At D:\src2\ClassLibrary1\packages\PropertyChanged.Fody.1.33.0.0\Tools\install.ps1:14 char:22
+ $node = $xml.Weavers[ <<<< $addinName]
    + CategoryInfo          : NotSpecified: (:) [], RuntimeException
    + FullyQualifiedErrorId : RuntimeException
```

This fixes that error.

Also added code to find the PropertyChanged reference and set it to CopyLocal false. This stops Costura from embedding the assembly, and other niceties.
