### PR TITLE
Equality checking of generics was invalid

### DIFF
--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -77,7 +77,7 @@ public class EqualityCheckWeaver
                     Instruction.Create(OpCodes.Box, targetType),
                     Instruction.Create(OpCodes.Ldarg_1),
                     Instruction.Create(OpCodes.Box, targetType),
-                    Instruction.Create(OpCodes.Ceq),
+                    Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
                     Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                     Instruction.Create(OpCodes.Ret));
             }

--- a/PropertyChanged.Fody/MsCoreReferenceFinder.cs
+++ b/PropertyChanged.Fody/MsCoreReferenceFinder.cs
@@ -8,6 +8,7 @@ public partial class ModuleWeaver
     public MethodReference ComponentModelPropertyChangedEventConstructorReference;
     public MethodReference ActionConstructorReference;
     public MethodReference ObjectConstructor;
+    public MethodReference ObjectEqualsMethod;
     public TypeReference ActionTypeReference;
     public MethodDefinition NullableEqualsMethod;
     public TypeReference PropChangedInterfaceReference;
@@ -31,6 +32,8 @@ public partial class ModuleWeaver
         }
         var constructorDefinition = objectDefinition.Methods.First(x => x.IsConstructor);
         ObjectConstructor = ModuleDefinition.Import(constructorDefinition);
+        var objectEqualsMethodDefiniton = objectDefinition.Methods.First(x => x.Name == "Equals" && x.Parameters.Count == 2);
+        ObjectEqualsMethod = ModuleDefinition.Import(objectEqualsMethodDefiniton);
 
 
         var nullableDefinition = msCoreTypes.FirstOrDefault(x => x.Name == "Nullable");
@@ -95,6 +98,8 @@ public partial class ModuleWeaver
 
         var constructorDefinition = objectDefinition.Methods.First(x => x.IsConstructor);
         ObjectConstructor = ModuleDefinition.Import(constructorDefinition);
+        var objectEqualsMethodDefiniton = objectDefinition.Methods.First(x => x.Name == "Equals" && x.Parameters.Count == 2);
+        ObjectEqualsMethod = ModuleDefinition.Import(objectEqualsMethodDefiniton);
 
 
         var nullableDefinition = systemRuntimeTypes.FirstOrDefault(x => x.Name == "Nullable");

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -397,6 +397,14 @@ public abstract class BaseTaskTests
         EventTester.TestProperty(instance, "SByteProperty", (sbyte)1);
         EventTester.TestProperty(instance, "CharProperty", 'd');
     }
+
+    [Test]
+    public void EqualityWithGeneric()
+    {
+        var instance = assembly.GetInstance("GenericBaseWithProperty.ClassWithGenericPropertyDouble");
+        EventTester.TestProperty(instance, "Property1", 1.0);
+    }
+
     [Test]
     public void WithCompilerGeneratedAttribute()
     {

--- a/TestAssemblies/AssemblyToProcess/GenericBaseWithProperty/ClassWithGenericPropertyChild.cs
+++ b/TestAssemblies/AssemblyToProcess/GenericBaseWithProperty/ClassWithGenericPropertyChild.cs
@@ -3,4 +3,8 @@
     public class ClassWithGenericPropertyChild : ClassWithGenericPropertyParent<string>
     {
     }
+
+    public class ClassWithGenericPropertyDouble : ClassWithGenericPropertyParent<double>
+    {
+    }
 }


### PR DESCRIPTION
The generated code was using == (op_equals) which is not allowed by the C# compiler.

Patched to use object.Equals(obj, obj) instead.
