### PR TITLE
Remove Strong Naming

### DIFF
--- a/PropertyChanged/PropertyChanged_3.5.csproj
+++ b/PropertyChanged/PropertyChanged_3.5.csproj
@@ -35,12 +35,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release_3.5\PropertyChanged.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/PropertyChanged/PropertyChanged_PCL.csproj
+++ b/PropertyChanged/PropertyChanged_PCL.csproj
@@ -34,12 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release_PCL\PropertyChanged.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet3.5.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet3.5.csproj
@@ -32,9 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet3.5Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet3.5Client.csproj
@@ -32,13 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
@@ -31,9 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="MediaBrowser.Model">
       <HintPath>..\..\packages\MediaBrowser.Common.3.0.175\lib\net35\MediaBrowser.Model.dll</HintPath>

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
@@ -32,9 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Once you've Strong Named, you can never go back. I'm sure that @kzu and @joaquinjares would love to [make a contribution in order to enable this un-feature](http://log.paulbetts.org/a-modest-proposal-strong-naming-carbon-offsets/). 
