### PR TITLE
Improve XML Doc for [ImplementPropertyChanged]

### DIFF
--- a/PropertyChanged/ImplementPropertyChangedAttribute.cs
+++ b/PropertyChanged/ImplementPropertyChangedAttribute.cs
@@ -4,9 +4,13 @@ namespace PropertyChanged
 {
     /// <summary>
     /// Specifies that PropertyChanged Notification will be added to a class.
+    /// <para>
     /// PropertyChanged.Fody will weave the <c>INotifyPropertyChanged</c> interface and implementation into the class.
     /// When the value of a property changes, the PropertyChanged notification will be raised automatically
-    /// See https://github.com/Fody/PropertyChanged for more information.
+    /// </para>
+    /// <para>
+    /// see https://github.com/Fody/PropertyChanged <see href="https://github.com/Fody/PropertyChanged">(link)</see> for more information.
+    /// </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class ImplementPropertyChangedAttribute : Attribute


### PR DESCRIPTION
I believe that for quite some developers the [ImplementPropertyChanged] will be the first point of contact with PropertyChanged weaving, Fody and even AOP in general.
I thought the property thus deserves a bit more high level / extensive documentation, including a link to the PropertyChanged.Fody website.
