### PR TITLE
Now detects (sender,arg) methods

### DIFF
--- a/PropertyChanged.Fody/InvokerTypes.cs
+++ b/PropertyChanged.Fody/InvokerTypes.cs
@@ -2,5 +2,6 @@
 {
     String,
     BeforeAfter,
-    PropertyChangedArg
+    PropertyChangedArg,
+    SenderPropertyChangedArg
 }

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -135,6 +135,10 @@ public class PropertyWeaver
         {
             return AddPropertyChangedArgInvokerCall(index, property);
         }
+        if (typeNode.EventInvoker.InvokerType == InvokerTypes.SenderPropertyChangedArg)
+        {
+            return AddSenderPropertyChangedArgInvokerCall(index, property);
+        }
         return AddSimpleInvokerCall(index, property);
     }
 
@@ -174,6 +178,16 @@ public class PropertyWeaver
     int AddPropertyChangedArgInvokerCall(int index, PropertyDefinition property)
     {
         return instructions.Insert(index,
+                                   Instruction.Create(OpCodes.Ldarg_0),
+                                   Instruction.Create(OpCodes.Ldstr, property.Name),
+                                   Instruction.Create(OpCodes.Newobj, moduleWeaver.ComponentModelPropertyChangedEventConstructorReference),
+                                   CallEventInvoker());
+    }
+
+    int AddSenderPropertyChangedArgInvokerCall(int index, PropertyDefinition property)
+    {
+        return instructions.Insert(index,
+                                   Instruction.Create(OpCodes.Ldarg_0),
                                    Instruction.Create(OpCodes.Ldarg_0),
                                    Instruction.Create(OpCodes.Ldstr, property.Name),
                                    Instruction.Create(OpCodes.Newobj, moduleWeaver.ComponentModelPropertyChangedEventConstructorReference),

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -878,6 +878,13 @@ public abstract class BaseTaskTests
     }
 
     [Test]
+    public void WithSenderPropertyChangedArgImplementation()
+    {
+        var instance = assembly.GetInstance("ClassWithSenderPropertyChangedArgImplementation");
+        EventTester.TestProperty(instance, true);
+    }
+
+    [Test]
     public void WithCustomPropertyChanged()
     {
         var instance = assembly.GetInstance("ClassWithCustomPropertyChanged");

--- a/PropertyChangedTests/MethodFinderTest.cs
+++ b/PropertyChangedTests/MethodFinderTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
 using Mono.Cecil;
 using NUnit.Framework;
 
@@ -31,6 +33,7 @@ public class MethodFinderTest
         var methodReference = methodFinder.RecursiveFindEventInvoker(definitionToProcess);
         Assert.IsNotNull(methodReference);
         Assert.AreEqual("OnPropertyChanged", methodReference.MethodReference.Name);
+        Assert.AreEqual(InvokerTypes.String, methodReference.InvokerType);
     }
 
     public class WithStringParam
@@ -58,6 +61,39 @@ public class MethodFinderTest
         }
     }
 
+    [Test]
+    public void WithPropertyChangedArgTest()
+    {
+        var definitionToProcess = typeDefinition.NestedTypes.First(x => x.Name == "WithPropertyChangedArg");
+        var methodReference = methodFinder.RecursiveFindEventInvoker(definitionToProcess);
+        Assert.IsNotNull(methodReference);
+        Assert.AreEqual("OnPropertyChanged", methodReference.MethodReference.Name);
+        Assert.AreEqual(InvokerTypes.PropertyChangedArg, methodReference.InvokerType);
+    }
+
+    public class WithPropertyChangedArg
+    {
+        public void OnPropertyChanged(PropertyChangedEventArgs arg)
+        {
+        }
+    }
+
+    [Test]
+    public void WithSenderPropertyChangedArgTest()
+    {
+        var definitionToProcess = typeDefinition.NestedTypes.First(x => x.Name == "WithSenderPropertyChangedArg");
+        var methodReference = methodFinder.RecursiveFindEventInvoker(definitionToProcess);
+        Assert.IsNotNull(methodReference);
+        Assert.AreEqual("OnPropertyChanged", methodReference.MethodReference.Name);
+        Assert.AreEqual(InvokerTypes.SenderPropertyChangedArg, methodReference.InvokerType);
+    }
+
+    public class WithSenderPropertyChangedArg
+    {
+        public void OnPropertyChanged(object sender, PropertyChangedEventArgs arg)
+        {
+        }
+    }
 
     [Test]
     public void NoMethodTest()

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ClassWithPropertyChangedArgImplementation.cs" />
     <Compile Include="ClassWithPropertySetInCatch.cs" />
     <Compile Include="ClassWithLdflda.cs" />
+    <Compile Include="ClassWithSenderPropertyChangedArgImplementation.cs" />
     <Compile Include="ClassWithSetterThatThrows.cs" />
     <Compile Include="ClassWithTernary.cs" />
     <Compile Include="ClassWithTryCatchInSet.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
@@ -97,6 +97,7 @@
     <Compile Include="ClassWithOwnImplementation.cs" />
     <Compile Include="ClassWithPropertyChangedArgImplementation.cs" />
     <Compile Include="ClassWithPropertySetInCatch.cs" />
+    <Compile Include="ClassWithSenderPropertyChangedArgImplementation.cs" />
     <Compile Include="ClassWithSetterThatThrows.cs" />
     <Compile Include="ClassWithTernary.cs" />
     <Compile Include="ClassWithTryCatchInSet.cs" />

--- a/TestAssemblies/AssemblyToProcess/ClassWithSenderPropertyChangedArgImplementation.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithSenderPropertyChangedArgImplementation.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithSenderPropertyChangedArgImplementation : INotifyPropertyChanged
+{
+
+    public string Property1 { get; set; }
+    [DependsOn("Property1")]
+    public string Property2 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public void OnPropertyChanged(object sender, PropertyChangedEventArgs arg)
+    {
+        var handler = PropertyChanged;
+        if (handler != null)
+        {
+            handler(sender, arg);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #105 

Turns out support for `OnPropertyChanged(object sender, PropertyChangedEventArgs arg)` was not there. This adds it.
