### PR TITLE
Added DoNotCheckEqualityAttribute

### DIFF
--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -50,7 +50,8 @@ public class EqualityCheckWeaver
 
     void InjectEqualityCheck(Instruction targetInstruction, TypeReference targetType)
     {
-
+        if (ShouldSkipEqualityCheck())
+            return;
         var nopInstruction = instructions.First();
         if (nopInstruction.OpCode != OpCodes.Nop)
         {
@@ -105,6 +106,12 @@ public class EqualityCheckWeaver
                 Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                 Instruction.Create(OpCodes.Ret));
         }
+    }
+
+    private bool ShouldSkipEqualityCheck()
+    {
+        return propertyData.PropertyDefinition.CustomAttributes
+            .ContainsAttribute("PropertyChanged.DoNotCheckEqualityAttribute");
     }
 
 }

--- a/PropertyChanged/DoNotCheckEqualityAttribute.cs
+++ b/PropertyChanged/DoNotCheckEqualityAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace PropertyChanged
+{
+    /// <summary>
+    /// Skip equality check before change notification
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class DoNotCheckEqualityAttribute : Attribute
+    {
+
+    }
+}

--- a/PropertyChanged/PropertyChanged.csproj
+++ b/PropertyChanged/PropertyChanged.csproj
@@ -47,6 +47,7 @@
     <Compile Include="AlsoNotifyForAttribute.cs" />
     <Compile Include="DependsOnAttribute.cs" />
     <Compile Include="DoNotNotifyAttribute.cs" />
+    <Compile Include="DoNotCheckEqualityAttribute.cs" />
     <Compile Include="DoNotSetChangedAttribute.cs" />
     <Compile Include="ImplementPropertyChangedAttribute.cs" />
   </ItemGroup>

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -497,6 +497,20 @@ public abstract class BaseTaskTests
         EventTester.TestProperty(instance, "Property1", (int?)1);
     }
 
+
+    [Test]
+    public void DoNotCheckEquality() 
+    {
+        var instance = assembly.GetInstance("ClassDoNotCheckEquality");
+        EventTester.TestProperty(instance, "Property1", "aString");
+        instance.Property1 = "aString";
+        Assert.AreEqual(1, instance.timesProperty1Changed);
+        
+        EventTester.TestProperty(instance, "Property2", "aString", true);
+        instance.Property2 = "aString";
+        Assert.AreEqual(2, instance.timesProperty2Changed);
+    }
+
     [Test]
     public void WithCompilerGeneratedAttribute()
     {

--- a/PropertyChangedTests/PropertyChangedTests.csproj
+++ b/PropertyChangedTests/PropertyChangedTests.csproj
@@ -153,5 +153,8 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PropertyChangedTests/PropertyChangedTests.csproj
+++ b/PropertyChangedTests/PropertyChangedTests.csproj
@@ -153,8 +153,5 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ClassAlsoNotifyForMultiple.cs" />
     <Compile Include="ClassCircularProperties.cs" />
     <Compile Include="ClassDependsOn.cs" />
+    <Compile Include="ClassDoNotCheckEquality.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ClassAlsoNotifyForMultiple.cs" />
     <Compile Include="ClassCircularProperties.cs" />
     <Compile Include="ClassDependsOn.cs" />
+    <Compile Include="ClassDoNotCheckEquality.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ClassAlsoNotifyForMultiple.cs" />
     <Compile Include="ClassCircularProperties.cs" />
     <Compile Include="ClassDependsOn.cs" />
+    <Compile Include="ClassDoNotCheckEquality.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />

--- a/TestAssemblies/AssemblyToProcess/ClassDoNotCheckEquality.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassDoNotCheckEquality.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+
+public class ClassDoNotCheckEquality : INotifyPropertyChanged
+{
+    public int timesProperty1Changed = 0;
+    public int timesProperty2Changed = 0;
+    
+    public string Property1 { get; set; }
+    
+    [PropertyChanged.DoNotCheckEquality]
+    public string Property2 { get; set; }
+
+    public void OnProperty1Changed() 
+    {
+        timesProperty1Changed += 1;
+    }
+
+    public void OnProperty2Changed()
+    {
+        timesProperty2Changed += 1;
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}


### PR DESCRIPTION
In some cases there is a need to raise property change notification on every property update even if the new value equals the old. My patch provides a DoNotCheckEqualityAttribute intended for marking properties that should not be checked for value equality.