### PR TITLE
DoNotCheckEquality needs to support "inherited" class attribute

### DIFF
--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -82,6 +82,23 @@ public static class CecilExtensions
         return reference;
     }
 
+    public static IEnumerable<CustomAttribute> GetAllCustomAttributes(this TypeDefinition typeDefinition)
+    {
+        foreach (var attribute in typeDefinition.CustomAttributes)
+        {
+            yield return attribute;
+        }
+
+        var baseDefinition = typeDefinition.BaseType as TypeDefinition;
+
+        if (baseDefinition != null)
+        {
+            foreach (var attribute in baseDefinition.GetAllCustomAttributes())
+            {
+                yield return attribute;
+            }
+        }
+    }
 
     public static CustomAttribute GetAttribute(this IEnumerable<CustomAttribute> attributes, string attributeName)
     {

--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -116,7 +116,7 @@ public class EqualityCheckWeaver
     {
         var attribute = "PropertyChanged.DoNotCheckEqualityAttribute";
 
-        return typeDefinition.CustomAttributes.ContainsAttribute(attribute)
+        return typeDefinition.GetAllCustomAttributes().ContainsAttribute(attribute)
                || propertyData.PropertyDefinition.CustomAttributes.ContainsAttribute(attribute);
     }
 

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -513,13 +513,29 @@ public abstract class BaseTaskTests
     [Test]
     public void DoNotCheckEqualityAppliesToWholeClass()
     {
+        var propertyValue = "aString";
         dynamic instance = assembly.GetInstance("ClassDoNotCheckEqualityWholeClass");
-        EventTester.TestProperty(instance, "Property1", "aString", true);
-        instance.Property1 = "aString";
+        EventTester.TestProperty(instance, "Property1", propertyValue, true);
+        instance.Property1 = propertyValue;
         Assert.AreEqual(2, instance.TimesProperty1Changed);
 
-        EventTester.TestProperty(instance, "Property2", "aString", true);
-        instance.Property2 = "aString";
+        EventTester.TestProperty(instance, "Property2", propertyValue, true);
+        instance.Property2 = propertyValue;
+        Assert.AreEqual(2, instance.TimesProperty2Changed);
+    }
+
+    [Test]
+    public void DoNotCheckEqualityAppliesToWholeClassInherited()
+    {
+        var propertyValue = "aString";
+        dynamic instance = assembly.GetInstance("ClassDoNotCheckEqualityWholeClassInherited");
+
+        EventTester.TestProperty(instance, "Property1", propertyValue, true);
+        instance.Property1 = propertyValue;
+        Assert.AreEqual(2, instance.TimesProperty1Changed);
+
+        EventTester.TestProperty(instance, "Property2", propertyValue, true);
+        instance.Property2 = propertyValue;
         Assert.AreEqual(2, instance.TimesProperty2Changed);
     }
 

--- a/TestAssemblies/AssemblyToProcess/ClassDoNotCheckEqualityWholeClass.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassDoNotCheckEqualityWholeClass.cs
@@ -7,7 +7,7 @@ public class ClassDoNotCheckEqualityWholeClass : INotifyPropertyChanged
     public int TimesProperty2Changed = 0;
 
     public string Property1 { get; set; }
-    
+
     public string Property2 { get; set; }
 
     public void OnProperty1Changed()
@@ -21,4 +21,9 @@ public class ClassDoNotCheckEqualityWholeClass : INotifyPropertyChanged
     }
 
     public event PropertyChangedEventHandler PropertyChanged;
+}
+
+public class ClassDoNotCheckEqualityWholeClassInherited : ClassDoNotCheckEqualityWholeClass
+{
+
 }


### PR DESCRIPTION
I have the attribute on a base class and all derived classes should disable equality.