### PR TITLE
Prevent NullReferenceException with obfuscated assemblies and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = crlf
+indent_style = space
+indent_size = 4

--- a/PropertyChanged.Fody/NotifyInterfaceFinder.cs
+++ b/PropertyChanged.Fody/NotifyInterfaceFinder.cs
@@ -25,6 +25,12 @@ public partial class ModuleWeaver
             typeDefinition = Resolve(typeReference);
         }
 
+        if (typeDefinition == null)
+        {
+            typeReferencesImplementingINotify[fullName] = false;
+            return false;
+        }
+
         if (HasPropertyChangedEvent(typeDefinition))
         {
             typeReferencesImplementingINotify[fullName] = true;
@@ -35,7 +41,7 @@ public partial class ModuleWeaver
             typeReferencesImplementingINotify[fullName] = true;
             return true;
         }
-        var baseType = typeDefinition != null ? typeDefinition.BaseType : null;
+        var baseType = typeDefinition.BaseType;
         if (baseType == null)
         {
             typeReferencesImplementingINotify[fullName] = false;

--- a/PropertyChanged.Fody/NotifyInterfaceFinder.cs
+++ b/PropertyChanged.Fody/NotifyInterfaceFinder.cs
@@ -35,7 +35,7 @@ public partial class ModuleWeaver
             typeReferencesImplementingINotify[fullName] = true;
             return true;
         }
-        var baseType = typeDefinition.BaseType;
+        var baseType = typeDefinition != null ? typeDefinition.BaseType : null;
         if (baseType == null)
         {
             typeReferencesImplementingINotify[fullName] = false;
@@ -49,7 +49,7 @@ public partial class ModuleWeaver
 
     public static bool HasPropertyChangedEvent(TypeDefinition typeDefinition)
     {
-        return typeDefinition.Events.Any(IsPropertyChangedEvent);
+        return typeDefinition != null && typeDefinition.Events.Any(IsPropertyChangedEvent);
     }
 
     public static bool IsPropertyChangedEvent(EventDefinition eventDefinition)
@@ -73,15 +73,18 @@ public partial class ModuleWeaver
 
     static bool HasPropertyChangedField(TypeDefinition typeDefinition)
     {
-        foreach (var fieldType in typeDefinition.Fields.Select(x => x.FieldType))
+        if (typeDefinition != null)
         {
-            if (fieldType.FullName == "Microsoft.FSharp.Control.FSharpEvent`2<System.ComponentModel.PropertyChangedEventHandler,System.ComponentModel.PropertyChangedEventArgs>")
+            foreach (var fieldType in typeDefinition.Fields.Select(x => x.FieldType))
             {
-                return true;
-            }
-            if (fieldType.FullName == "Microsoft.FSharp.Control.FSharpEvent`2<Windows.UI.Xaml.Data.PropertyChangedEventHandler,Windows.UI.Xaml.Data.PropertyChangedEventArgs>")
-            {
-                return true;
+                 if (fieldType.FullName == "Microsoft.FSharp.Control.FSharpEvent`2<System.ComponentModel.PropertyChangedEventHandler,System.ComponentModel.PropertyChangedEventArgs>")
+                 {
+                     return true;
+                 }
+                 if (fieldType.FullName == "Microsoft.FSharp.Control.FSharpEvent`2<Windows.UI.Xaml.Data.PropertyChangedEventHandler,Windows.UI.Xaml.Data.PropertyChangedEventArgs>")
+                 {
+                     return true;
+                 }
             }
         }
         return false;

--- a/PropertyChanged.Fody/SupportsCeqChecker.cs
+++ b/PropertyChanged.Fody/SupportsCeqChecker.cs
@@ -39,7 +39,8 @@ public static class SupportsCeqChecker
         var typeDefinition = typeReference.Resolve();
         if (typeDefinition == null)
         {
-            throw new Exception(string.Format("Could not resolve '{0}'.", typeReference.FullName));
+            //throw new Exception(string.Format("Could not resolve '{0}'.", typeReference.FullName));
+            return false; // obfuscated reference
         }
         if (typeDefinition.IsEnum)
         {

--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -87,7 +87,7 @@ public partial class ModuleWeaver
     MethodReference GetStaticEquality(TypeReference typeReference)
     {
         var typeDefinition = Resolve(typeReference);
-        if (typeDefinition.IsInterface)
+        if (typeDefinition == null || typeDefinition.IsInterface)
         {
             return null;
         }
@@ -97,6 +97,10 @@ public partial class ModuleWeaver
 
     public static MethodReference FindNamedMethod(TypeDefinition typeDefinition)
     {
+        if (typeDefinition == null)
+        {
+          return null;        
+        }
         var equalsMethod = FindNamedMethod(typeDefinition, "Equals");
         if (equalsMethod == null)
         {

--- a/PropertyChanged.Fody/TypeResolver.cs
+++ b/PropertyChanged.Fody/TypeResolver.cs
@@ -24,7 +24,8 @@ public partial class ModuleWeaver
         }
         catch (Exception exception)
         {
-            throw new Exception(string.Format("Could not resolve '{0}'.", reference.FullName), exception);
+            //throw new Exception(string.Format("Could not resolve '{0}'.", reference.FullName), exception);
+            return null; // obfuscated reference
         }
     }
 }


### PR DESCRIPTION
When using PropertyChanged in a project that references obfuscated assemblies, a NullReferenceExceptions occurs in "PropertyChanged.Fody/NotifyInterfaceFinder.cs" because typeDefinition is not tested against null. Also, please add ".editorconfig" so that one doesn't have to configure Visual Studio when working with different solutions (see editorconfig.org).