### PR TITLE
added configuration option for CheckForEquality

### DIFF
--- a/PropertyChanged.Fody/CheckForEqualityConfig.cs
+++ b/PropertyChanged.Fody/CheckForEqualityConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+
+public partial class ModuleWeaver
+{
+    public bool CheckForEquality = true;
+
+    public void ResolveCheckForEqualityConfig()
+    {
+        if (Config != null)
+        {
+            var value = Config.Attributes("CheckForEquality").FirstOrDefault();
+            if (value != null)
+            {
+                CheckForEquality = bool.Parse((string)value);
+            }
+        }
+    }
+}

--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -114,6 +114,11 @@ public class EqualityCheckWeaver
 
     bool ShouldSkipEqualityCheck()
     {
+        if (!typeEqualityFinder.CheckForEquality)
+        {
+            return true;
+        }
+
         var attribute = "PropertyChanged.DoNotCheckEqualityAttribute";
 
         return typeDefinition.GetAllCustomAttributes().ContainsAttribute(attribute)

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -21,6 +21,7 @@ public partial class ModuleWeaver
     public void Execute()
     {
         ResolveOnPropertyNameChangedConfig();
+        ResolveCheckForEqualityConfig();
         ResolveEventInvokerName();
         FindCoreReferences();
         FindInterceptor();

--- a/PropertyChanged.Fody/PropertyChanged.Fody.csproj
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.csproj
@@ -63,6 +63,7 @@
     <Compile Include="AlreadyNotifyFinder.cs" />
     <Compile Include="AttributeCleaner.cs" />
     <Compile Include="CecilExtensions.cs" />
+    <Compile Include="CheckForEqualityConfig.cs" />
     <Compile Include="CodeGenTypeCleaner.cs" />
     <Compile Include="InjectOnPropertyNameChangedConfig.cs" />
     <Compile Include="EqualityCheckWeaver.cs" />

--- a/PropertyChangedTests/CheckForEqualityConfigTests.cs
+++ b/PropertyChangedTests/CheckForEqualityConfigTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Xml.Linq;
+using NUnit.Framework;
+
+[TestFixture]
+public class CheckForEqualityConfigTests
+{
+    [Test]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged CheckForEquality='false'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveCheckForEqualityConfig();
+        Assert.IsFalse(moduleWeaver.CheckForEquality);
+    }
+
+    [Test]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged CheckForEquality='true'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveCheckForEqualityConfig();
+        Assert.IsTrue(moduleWeaver.CheckForEquality);
+    }
+
+    [Test]
+    public void Default()
+    {
+        var moduleWeaver = new ModuleWeaver();
+        moduleWeaver.ResolveCheckForEqualityConfig();
+        Assert.IsTrue(moduleWeaver.CheckForEquality);
+    }
+}

--- a/PropertyChangedTests/OnPropertyNameChangedConfigTests.cs
+++ b/PropertyChangedTests/OnPropertyNameChangedConfigTests.cs
@@ -29,5 +29,4 @@ public class OnPropertyNameChangedConfigTests
         moduleWeaver.ResolveOnPropertyNameChangedConfig();
         Assert.IsTrue(moduleWeaver.InjectOnPropertyNameChanged);
     }
-
 }

--- a/PropertyChangedTests/PropertyChangedTests.csproj
+++ b/PropertyChangedTests/PropertyChangedTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="AssemblyWithBadNamedInvokerTests.cs" />
     <Compile Include="AssemblyWithInterceptorTests.cs" />
     <Compile Include="Attributes\NotifyPropertyChangedAttribute.cs" />
+    <Compile Include="CheckForEqualityConfigTests.cs" />
     <Compile Include="EventInvokerNamesConfigTests.cs" />
     <Compile Include="MappingFinder\MappingFinderSingleBackingReadonlyFieldGet.cs" />
     <Compile Include="MappingFinder\MappingFinderSingleBackingConstantFieldGet.cs" />


### PR DESCRIPTION
I added the configuration option CheckForEquality which existed in the old NotifyPropertyWeaver and didn't make the transition to PropertyChanged.Fody.
There are some cases where it's more convenient to just ignore the equality check for a whole project instead of setting the DoNotCheckEquality attribute on thousands of properties.
I hope you can merge this back to your main branch so it will be included in future releases.
