### PR TITLE
Expand IsChanged matching to include protected properties.

### DIFF
--- a/PropertyChanged.Fody/IsChangedMethodFinder.cs
+++ b/PropertyChanged.Fody/IsChangedMethodFinder.cs
@@ -79,7 +79,7 @@ public partial class ModuleWeaver
             .FirstOrDefault(x =>
                             x.Name == isChangedPropertyName &&
                             x.SetMethod != null &&
-                            x.SetMethod.IsPublic
+                            (x.SetMethod.IsPublic || x.SetMethod.IsFamily || x.SetMethod.IsFamilyOrAssembly)
             );
 
 


### PR DESCRIPTION
Some of the comments in #50 were that perhaps limiting IsChanged to only public setters was too restrictive.  I myself would like to have IsChanged set on a protected setter.