### PR TITLE
added test casses for generic types with == implemented

### DIFF
--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -95,7 +95,7 @@ public partial class ModuleWeaver
         return FindNamedMethod(typeDefinition);
     }
 
-    public static MethodReference FindNamedMethod(TypeDefinition typeDefinition)
+    public MethodReference FindNamedMethod(TypeDefinition typeDefinition)
     {
         var equalsMethod = FindNamedMethod(typeDefinition, "Equals");
         if (equalsMethod == null)
@@ -105,14 +105,26 @@ public partial class ModuleWeaver
         return equalsMethod;
     }
 
-    static MethodReference FindNamedMethod(TypeDefinition typeDefinition, string methodName)
+    MethodReference FindNamedMethod(TypeDefinition typeDefinition, string methodName)
     {
-        return typeDefinition.Methods.FirstOrDefault(x => x.Name == methodName &&
-                                                          x.IsStatic &&
-                                                          x.ReturnType.Name == "Boolean" &&
-                                                          x.HasParameters &&
-                                                          x.Parameters.Count == 2 &&
-                                                          x.Parameters[0].ParameterType == typeDefinition &&
-                                                          x.Parameters[1].ParameterType == typeDefinition);
+        return typeDefinition.Methods.FirstOrDefault(x => Check(x, typeDefinition, methodName));
+    }
+
+    bool Check(MethodDefinition x, TypeDefinition typeDefinition, string methodName)
+    {
+
+        bool isMatch = x.Name == methodName &&
+                        x.IsStatic &&
+                        x.ReturnType.Name == "Boolean" &&
+                        x.HasParameters &&
+                        x.Parameters.Count == 2;
+        if (isMatch)
+        {
+            // compare generic parameter types properly
+            var td1 = Resolve(x.Parameters[0].ParameterType);
+            var td2 = Resolve(x.Parameters[1].ParameterType);
+            isMatch = td1 == typeDefinition && td2 == typeDefinition;
+        }
+        return isMatch;
     }
 }

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -1280,6 +1280,56 @@ public abstract class BaseTaskTests
     }
 
     [Test]
+    public void EqualityWithGenericClassOverload()
+    {
+        var instance = assembly.GetInstance("ClassEqualityWithGenericClassOverload");
+        var property1EventCalled = false;
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == "Property1")
+            {
+                property1EventCalled = true;
+            }
+        };
+        var property1 = assembly.GetGenericInstance("ClassEqualityWithGenericClassOverload+SimpleClass`1", new Type[] { typeof(int) });
+        property1.X = 5;
+        instance.Property1 = property1;
+
+        Assert.IsTrue(property1EventCalled);
+        property1EventCalled = false;
+        //Property Equals has not changed on re-set so event not fired
+        var property2 = assembly.GetGenericInstance("ClassEqualityWithGenericClassOverload+SimpleClass`1", new Type[] { typeof(int) });
+        property2.X = 5;
+        instance.Property1 = property2;
+        Assert.IsFalse(property1EventCalled);
+    }
+
+    [Test]
+    public void EqualityWithGenericStructOverload()
+    {
+        var instance = assembly.GetInstance("ClassEqualityWithGenericStructOverload");
+        var property1EventCalled = false;
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == "Property1")
+            {
+                property1EventCalled = true;
+            }
+        };
+        var property1 = assembly.GetGenericInstance("ClassEqualityWithGenericStructOverload+SimpleStruct`1", new Type[] { typeof(int) });
+        property1.X = 5;
+        instance.Property1 = property1;
+
+        Assert.IsTrue(property1EventCalled);
+        property1EventCalled = false;
+        //Property Equals has not changed on re-set so event not fired
+        var property2 = assembly.GetGenericInstance("ClassEqualityWithGenericStructOverload+SimpleStruct`1", new Type[] { typeof(int) });
+        property2.X = 5;
+        instance.Property1 = property2;
+        Assert.IsFalse(property1EventCalled);
+    }
+
+    [Test]
     public void PeVerify()
     {
         Verifier.Verify(weaverHelper.BeforeAssemblyPath, weaverHelper.AfterAssemblyPath);

--- a/PropertyChangedTests/EventTester.cs
+++ b/PropertyChangedTests/EventTester.cs
@@ -83,4 +83,11 @@ public static class EventTester
         //dynamic instance = FormatterServices.GetUninitializedObject(type);
         return Activator.CreateInstance(type);
     }
+
+    public static dynamic GetGenericInstance(this Assembly assembly, string className, Type[] typeArguments)
+    {
+        var type = assembly.GetType(className, true);
+        Type constructedType = type.MakeGenericType(typeArguments);
+        return Activator.CreateInstance(constructedType);
+    }
 }

--- a/PropertyChangedTests/TypeEqualityFinderTests.cs
+++ b/PropertyChangedTests/TypeEqualityFinderTests.cs
@@ -8,21 +8,21 @@ public class TypeEqualityFinderTests
     public void TestSqlGuid()
     {
         var typeDefinition = DefinitionFinder.FindType<SqlGuid>();
-        var findNamedMethod = ModuleWeaver  .FindNamedMethod(typeDefinition);
+        var findNamedMethod = new ModuleWeaver().FindNamedMethod(typeDefinition);
         Assert.IsNull(findNamedMethod);
     }
     [Test]
     public void TestInt()
     {
         var typeDefinition = DefinitionFinder.FindType<int>();
-        var findNamedMethod = ModuleWeaver.FindNamedMethod(typeDefinition);
+        var findNamedMethod = new ModuleWeaver().FindNamedMethod(typeDefinition);
         Assert.IsNull(findNamedMethod);
     }
     [Test]
     public void TestString()
     {
         var typeDefinition = DefinitionFinder.FindType<string>();
-        var findNamedMethod = ModuleWeaver.FindNamedMethod(typeDefinition);
+        var findNamedMethod = new ModuleWeaver().FindNamedMethod(typeDefinition);
         Assert.AreEqual("System.Boolean System.String::Equals(System.String,System.String)", findNamedMethod.FullName);
     }
 }

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
@@ -52,6 +52,8 @@
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassMissingSetGet.cs" />
     <Compile Include="ClassNoBackingNoEqualityField.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
@@ -55,6 +55,8 @@
     <Compile Include="ClassDoNotCheckEqualityWholeClass.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassMissingSetGet.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ClassDoNotCheckEqualityWholeClass.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassWithOnChangedAndNoPropertyChanged.cs" />

--- a/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericClassOverload.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericClassOverload.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+
+public class ClassEqualityWithGenericClassOverload : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+    public SimpleClass<int> Property1 { get; set; }
+    
+    public class SimpleClass<T>
+    {
+        public int X ;
+        public override bool Equals(object obj)
+        {
+            SimpleClass<T> other = obj as SimpleClass<T>;
+            return Equals(this, other);
+        }
+        public static bool Equals(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            if (object.ReferenceEquals(left, null) && object.ReferenceEquals(right, null))
+                return true;
+            if (object.ReferenceEquals(left, null) || object.ReferenceEquals(right, null))
+                return false;
+            return left.X == right.X;
+        }
+        public override int GetHashCode()
+        {
+            return X.GetHashCode();
+        }
+        public static bool operator ==(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericStructOverload.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericStructOverload.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+
+public class ClassEqualityWithGenericStructOverload : INotifyPropertyChanged
+{
+    public SimpleStruct<int> Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    
+#pragma warning disable 660,661
+    public struct SimpleStruct<T>
+#pragma warning restore 660,661
+    {
+
+        public int X ;
+        public static bool operator ==(SimpleStruct<T> left, SimpleStruct<T> right)
+        {
+            return left.X == right.X;
+        }
+
+        public static bool operator !=(SimpleStruct<T> left, SimpleStruct<T> right)
+        {
+            return !(left == right);
+        }
+    }
+
+}


### PR DESCRIPTION
Looks like Equals or == operator aren't used when property type is a generic type.
Added two test cases, one with a generic class and the other with a generic struct.