### PR TITLE
Generic types with op_equality overrides fix

### DIFF
--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -89,6 +89,16 @@ public class EqualityCheckWeaver
                     Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                     Instruction.Create(OpCodes.Ret));
             }
+            else if (targetType.IsGenericInstance)
+            {
+                instructions.Prepend(
+                    Instruction.Create(OpCodes.Ldarg_0),
+                    targetInstruction,
+                    Instruction.Create(OpCodes.Ldarg_1),
+                    Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
+                    Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
+                    Instruction.Create(OpCodes.Ret));
+            }
             else if (targetType.SupportsCeq())
             {
                 instructions.Prepend(

--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -77,7 +77,7 @@ public class EqualityCheckWeaver
         var typeEqualityMethod = typeEqualityFinder.FindTypeEquality(targetType);
         if (typeEqualityMethod == null)
         {
-            if (targetType.IsGenericParameter)
+            if (targetType.IsGenericParameter || targetType.IsValueType)
             {
                 instructions.Prepend(
                     Instruction.Create(OpCodes.Ldarg_0),
@@ -85,16 +85,6 @@ public class EqualityCheckWeaver
                     Instruction.Create(OpCodes.Box, targetType),
                     Instruction.Create(OpCodes.Ldarg_1),
                     Instruction.Create(OpCodes.Box, targetType),
-                    Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
-                    Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
-                    Instruction.Create(OpCodes.Ret));
-            }
-            else if (targetType.IsGenericInstance)
-            {
-                instructions.Prepend(
-                    Instruction.Create(OpCodes.Ldarg_0),
-                    targetInstruction,
-                    Instruction.Create(OpCodes.Ldarg_1),
                     Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
                     Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                     Instruction.Create(OpCodes.Ret));
@@ -106,6 +96,16 @@ public class EqualityCheckWeaver
                     targetInstruction,
                     Instruction.Create(OpCodes.Ldarg_1),
                     Instruction.Create(OpCodes.Ceq),
+                    Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
+                    Instruction.Create(OpCodes.Ret));
+            }
+            else
+            {
+                instructions.Prepend(
+                    Instruction.Create(OpCodes.Ldarg_0),
+                    targetInstruction,
+                    Instruction.Create(OpCodes.Ldarg_1),
+                    Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
                     Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                     Instruction.Create(OpCodes.Ret));
             }

--- a/PropertyChanged.Fody/SupportsCeqChecker.cs
+++ b/PropertyChanged.Fody/SupportsCeqChecker.cs
@@ -36,6 +36,10 @@ public static class SupportsCeqChecker
         {
             return false;
         }
+        if (typeReference.ContainsGenericParameter)
+        {
+            return false;
+        }
         var typeDefinition = typeReference.Resolve();
         if (typeDefinition == null)
         {

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -1280,6 +1280,56 @@ public abstract class BaseTaskTests
     }
 
     [Test]
+    public void EqualityWithGenericClassOverload()
+    {
+        var instance = assembly.GetInstance("ClassEqualityWithGenericClassOverload");
+        var property1EventCalled = false;
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == "Property1")
+            {
+                property1EventCalled = true;
+            }
+        };
+        var property1 = assembly.GetGenericInstance("ClassEqualityWithGenericClassOverload+SimpleClass`1", new Type[] { typeof(int) });
+        property1.X = 5;
+        instance.Property1 = property1;
+
+        Assert.IsTrue(property1EventCalled);
+        property1EventCalled = false;
+        //Property Equals has not changed on re-set so event not fired
+        var property2 = assembly.GetGenericInstance("ClassEqualityWithGenericClassOverload+SimpleClass`1", new Type[] { typeof(int) });
+        property2.X = 5;
+        instance.Property1 = property2;
+        Assert.IsFalse(property1EventCalled);
+    }
+
+    [Test]
+    public void EqualityWithGenericStructOverload()
+    {
+        var instance = assembly.GetInstance("ClassEqualityWithGenericStructOverload");
+        var property1EventCalled = false;
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == "Property1")
+            {
+                property1EventCalled = true;
+            }
+        };
+        var property1 = assembly.GetGenericInstance("ClassEqualityWithGenericStructOverload+SimpleStruct`1", new Type[] { typeof(int) });
+        property1.X = 5;
+        instance.Property1 = property1;
+
+        Assert.IsTrue(property1EventCalled);
+        property1EventCalled = false;
+        //Property Equals has not changed on re-set so event not fired
+        var property2 = assembly.GetGenericInstance("ClassEqualityWithGenericStructOverload+SimpleStruct`1", new Type[] { typeof(int) });
+        property2.X = 5;
+        instance.Property1 = property2;
+        Assert.IsFalse(property1EventCalled);
+    }
+
+    [Test]
     public void PeVerify()
     {
         Verifier.Verify(weaverHelper.BeforeAssemblyPath, weaverHelper.AfterAssemblyPath);

--- a/PropertyChangedTests/BaseTaskTests.cs
+++ b/PropertyChangedTests/BaseTaskTests.cs
@@ -1252,10 +1252,15 @@ public abstract class BaseTaskTests
                 property1EventCalled = true;
             }
         };
-        var property1 = assembly.GetInstance("ClassEqualityWithStruct+SimpleStruct");
+        var property1 = assembly.GetInstance("ClassEqualityWithStruct+SimpleStruct", 1);
         instance.Property1 = property1;
         Assert.IsTrue(property1EventCalled);
+        property1EventCalled = false;
+        property1 = assembly.GetInstance("ClassEqualityWithStruct+SimpleStruct", 1);
+        instance.Property1 = property1;
+        Assert.IsFalse(property1EventCalled);
     }
+
     [Test]
     public void EqualityWithStructOverload()
     {

--- a/PropertyChangedTests/EventTester.cs
+++ b/PropertyChangedTests/EventTester.cs
@@ -83,4 +83,11 @@ public static class EventTester
         //dynamic instance = FormatterServices.GetUninitializedObject(type);
         return Activator.CreateInstance(type);
     }
+
+    public static dynamic GetGenericInstance(this Assembly assembly, string className, Type[] typeArguments)
+    {
+        var type = assembly.GetType(className, true);
+        Type constructedType = type.MakeGenericType(typeArguments);
+        return Activator.CreateInstance(constructedType);
+    }
 }

--- a/PropertyChangedTests/EventTester.cs
+++ b/PropertyChangedTests/EventTester.cs
@@ -77,11 +77,11 @@ public static class EventTester
         Assert.IsFalse(eventCalled);
     }
 
-    public static dynamic GetInstance(this Assembly assembly, string className)
+    public static dynamic GetInstance(this Assembly assembly, string className, params object[] args)
     {
         var type = assembly.GetType(className, true);
         //dynamic instance = FormatterServices.GetUninitializedObject(type);
-        return Activator.CreateInstance(type);
+        return Activator.CreateInstance(type, args);
     }
 
     public static dynamic GetGenericInstance(this Assembly assembly, string className, Type[] typeArguments)

--- a/PropertyChangedTests/Verifier.cs
+++ b/PropertyChangedTests/Verifier.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
-
+using Microsoft.Build.Utilities;
 
 public static class Verifier
 {
@@ -11,18 +12,14 @@ public static class Verifier
 
     static Verifier()
     {
-        
-        exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
+        var sdkPath = Path.GetFullPath(Path.Combine(ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest), "..\\.."));
+        exePath = Directory.GetFiles(sdkPath, "peverify.exe", SearchOption.AllDirectories).LastOrDefault();
 
-        if (!File.Exists(exePath))
-        {
-            exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
-        }
         peverifyFound = File.Exists(exePath);
         if (!peverifyFound)
         {
 #if(!DEBUG)
-            throw new Exception("Could not fund PEVerify");
+            throw new Exception("Could not find PEVerify");
 #endif
         }
     }

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4.csproj
@@ -52,6 +52,8 @@
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassMissingSetGet.cs" />
     <Compile Include="ClassNoBackingNoEqualityField.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessDotNet4Client.csproj
@@ -55,6 +55,8 @@
     <Compile Include="ClassDoNotCheckEqualityWholeClass.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassMissingSetGet.cs" />

--- a/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
+++ b/TestAssemblies/AssemblyToProcess/AssemblyToProcessPhone.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ClassDoNotCheckEqualityWholeClass.cs" />
     <Compile Include="ClassEquality.cs" />
     <Compile Include="ClassEqualityWithDouble.cs" />
+    <Compile Include="ClassEqualityWithGenericClassOverload.cs" />
+    <Compile Include="ClassEqualityWithGenericStructOverload.cs" />
     <Compile Include="ClassEqualityWithStruct.cs" />
     <Compile Include="ClassEqualityWithStructOverload.cs" />
     <Compile Include="ClassWithOnChangedAndNoPropertyChanged.cs" />

--- a/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericClassOverload.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericClassOverload.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+
+public class ClassEqualityWithGenericClassOverload : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+    public SimpleClass<int> Property1 { get; set; }
+    
+    public class SimpleClass<T>
+    {
+        public int X ;
+        public override bool Equals(object obj)
+        {
+            SimpleClass<T> other = obj as SimpleClass<T>;
+            return Equals(this, other);
+        }
+        public static bool Equals(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            if (object.ReferenceEquals(left, null) && object.ReferenceEquals(right, null))
+                return true;
+            if (object.ReferenceEquals(left, null) || object.ReferenceEquals(right, null))
+                return false;
+            return left.X == right.X;
+        }
+        public override int GetHashCode()
+        {
+            return X.GetHashCode();
+        }
+        public static bool operator ==(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(SimpleClass<T> left, SimpleClass<T> right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericStructOverload.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassEqualityWithGenericStructOverload.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+
+public class ClassEqualityWithGenericStructOverload : INotifyPropertyChanged
+{
+    public SimpleStruct<int> Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    
+#pragma warning disable 660,661
+    public struct SimpleStruct<T>
+#pragma warning restore 660,661
+    {
+
+        public int X ;
+        public static bool operator ==(SimpleStruct<T> left, SimpleStruct<T> right)
+        {
+            return left.X == right.X;
+        }
+
+        public static bool operator !=(SimpleStruct<T> left, SimpleStruct<T> right)
+        {
+            return !(left == right);
+        }
+    }
+
+}

--- a/TestAssemblies/AssemblyToProcess/ClassEqualityWithStruct.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassEqualityWithStruct.cs
@@ -5,9 +5,14 @@ public class ClassEqualityWithStruct : INotifyPropertyChanged
     public SimpleStruct Property1 { get; set; }
 
     public event PropertyChangedEventHandler PropertyChanged;
-    
+
     public struct SimpleStruct
     {
-    }
+        public int X;
 
+        public SimpleStruct(int x)
+        {
+            X = x;
+        }
+    }
 }


### PR DESCRIPTION
PR #164 has tests for this, but the fix was more complex than it needed to be.

Instead `object.Equals()` is enough to call the correct override, making the code we need simpler.

This PR keeps the failing tests from #164 but implements the simpler solution.