### PR TITLE
Throw an exception if InnerResolve returns null

### DIFF
--- a/PropertyChanged.Fody/TypeResolver.cs
+++ b/PropertyChanged.Fody/TypeResolver.cs
@@ -18,13 +18,22 @@ public partial class ModuleWeaver
 
     static TypeDefinition InnerResolve(TypeReference reference)
     {
+        TypeDefinition result = null;
+
         try
         {
-            return reference.Resolve();
+            result = reference.Resolve();
         }
         catch (Exception exception)
         {
             throw new Exception($"Could not resolve '{reference.FullName}'.", exception);
         }
+
+        if(result == null)
+        {
+            throw new Exception($"Could not resolve '{reference.FullName}'.");
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
Not sure I fully understand _why_ this happens, but I have `NullReferenceExceptions` when building with Fody.

It took some time to figure out this was because the `TypeResolver` returns `null` for a specific type; this PR makes Fody throw an exception with a clear error message if that happens.