### PR TITLE
Equality fixes

### DIFF
--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -32,16 +32,14 @@ public class EqualityCheckWeaver
         }
     }
 
-
     void CheckAgainstField()
     {
         var fieldReference = propertyData.BackingFieldReference.Resolve().GetGeneric();
         if (propertyData.BackingFieldReference.FieldType.FullName == propertyData.PropertyDefinition.PropertyType.FullName)
         {
-            InjectEqualityCheck(Instruction.Create(OpCodes.Ldfld, fieldReference), fieldReference.FieldType);   
+            InjectEqualityCheck(Instruction.Create(OpCodes.Ldfld, fieldReference), fieldReference.FieldType);
         }
     }
-
 
     void CheckAgainstProperty()
     {
@@ -77,7 +75,17 @@ public class EqualityCheckWeaver
         var typeEqualityMethod = typeEqualityFinder.FindTypeEquality(targetType);
         if (typeEqualityMethod == null)
         {
-            if (targetType.IsGenericParameter || targetType.IsValueType)
+            if (targetType.SupportsCeq() && targetType.IsValueType)
+            {
+                instructions.Prepend(
+                    Instruction.Create(OpCodes.Ldarg_0),
+                    targetInstruction,
+                    Instruction.Create(OpCodes.Ldarg_1),
+                    Instruction.Create(OpCodes.Ceq),
+                    Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
+                    Instruction.Create(OpCodes.Ret));
+            }
+            else if (targetType.IsGenericParameter || targetType.IsValueType)
             {
                 instructions.Prepend(
                     Instruction.Create(OpCodes.Ldarg_0),
@@ -86,16 +94,6 @@ public class EqualityCheckWeaver
                     Instruction.Create(OpCodes.Ldarg_1),
                     Instruction.Create(OpCodes.Box, targetType),
                     Instruction.Create(OpCodes.Call, typeEqualityFinder.ObjectEqualsMethod),
-                    Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
-                    Instruction.Create(OpCodes.Ret));
-            }
-            else if (targetType.SupportsCeq())
-            {
-                instructions.Prepend(
-                    Instruction.Create(OpCodes.Ldarg_0),
-                    targetInstruction,
-                    Instruction.Create(OpCodes.Ldarg_1),
-                    Instruction.Create(OpCodes.Ceq),
                     Instruction.Create(OpCodes.Brfalse_S, nopInstruction),
                     Instruction.Create(OpCodes.Ret));
             }
@@ -134,5 +132,4 @@ public class EqualityCheckWeaver
         return typeDefinition.GetAllCustomAttributes().ContainsAttribute(attribute)
                || propertyData.PropertyDefinition.CustomAttributes.ContainsAttribute(attribute);
     }
-
 }

--- a/PropertyChanged.Fody/MsCoreReferenceFinder.cs
+++ b/PropertyChanged.Fody/MsCoreReferenceFinder.cs
@@ -9,6 +9,7 @@ public partial class ModuleWeaver
     public MethodReference ActionConstructorReference;
     public MethodReference ObjectConstructor;
     public MethodReference ObjectEqualsMethod;
+    public TypeReference EqualityComparerTypeReference;
     public TypeReference ActionTypeReference;
     public MethodDefinition NullableEqualsMethod;
     public TypeReference PropChangedInterfaceReference;
@@ -16,7 +17,6 @@ public partial class ModuleWeaver
     public MethodReference DelegateCombineMethodRef;
     public MethodReference DelegateRemoveMethodRef;
     public GenericInstanceMethod InterlockedCompareExchangeForPropChangedHandler;
-
 
     public void FindCoreReferences()
     {
@@ -35,9 +35,10 @@ public partial class ModuleWeaver
         var objectEqualsMethodDefinition = objectDefinition.Methods.First(x => x.Name == "Equals" && x.Parameters.Count == 2);
         ObjectEqualsMethod = ModuleDefinition.ImportReference(objectEqualsMethodDefinition);
 
-
         var nullableDefinition = msCoreTypes.FirstOrDefault(x => x.Name == "Nullable");
         NullableEqualsMethod = ModuleDefinition.ImportReference(nullableDefinition).Resolve().Methods.First(x => x.Name == "Equals");
+
+        EqualityComparerTypeReference = msCoreTypes.FirstOrDefault(x => x.Name == "EqualityComparer`1");
 
         var systemDefinition = assemblyResolver.Resolve("System");
         var systemTypes = systemDefinition.MainModule.Types;
@@ -101,16 +102,15 @@ public partial class ModuleWeaver
         var objectEqualsMethodDefinition = objectDefinition.Methods.First(x => x.Name == "Equals" && x.Parameters.Count == 2);
         ObjectEqualsMethod = ModuleDefinition.ImportReference(objectEqualsMethodDefinition);
 
-
         var nullableDefinition = systemRuntimeTypes.FirstOrDefault(x => x.Name == "Nullable");
         NullableEqualsMethod = ModuleDefinition.ImportReference(nullableDefinition).Resolve().Methods.First(x => x.Name == "Equals");
 
+        EqualityComparerTypeReference = systemRuntimeTypes.FirstOrDefault(x => x.Name == "EqualityComparer`1");
 
         var actionDefinition = systemRuntimeTypes.First(x => x.Name == "Action");
         ActionTypeReference = ModuleDefinition.ImportReference(actionDefinition);
         var actionConstructor = actionDefinition.Methods.First(x => x.IsConstructor);
         ActionConstructorReference = ModuleDefinition.ImportReference(actionConstructor);
-
 
         var systemObjectModel = assemblyResolver.Resolve("System.ObjectModel");
         var systemObjectModelTypes = systemObjectModel.MainModule.Types;
@@ -147,7 +147,6 @@ public partial class ModuleWeaver
         InterlockedCompareExchangeForPropChangedHandler = new GenericInstanceMethod(genericCompareExchangeMethod);
         InterlockedCompareExchangeForPropChangedHandler.GenericArguments.Add(PropChangedHandlerReference);
     }
-
 
     AssemblyDefinition GetSystemCoreDefinition()
     {


### PR DESCRIPTION
Changed equality checker code based on the discussion in #191.

- Base types (int, byte, etc.) have been fixed to use `ceq`
- Structs now use `EqualityComparer`
- objects still use `object.Equals`
- if there's an equals method on the type it uses that, so no change there