### PR TITLE
Support for generic OnPropertyChanged BeforeAfter method

### DIFF
--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -67,11 +67,7 @@ public static class CecilExtensions
             var methodReference = new MethodReference(reference.Name, reference.MethodReturnType.ReturnType, declaringType);
             if (reference.HasGenericParameters)
             {
-                foreach (var p in reference.GenericParameters)
-                {
-                    var gp=new GenericParameter(p.Name,reference);
-                    methodReference.GenericParameters.Add(gp);
-                }
+                ModuleWeaver.ImportGenericParameters(methodReference, reference);
             }
             foreach (var parameterDefinition in reference.Parameters)
             {

--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -65,6 +65,14 @@ public static class CecilExtensions
                 declaringType.GenericArguments.Add(parameter);
             }
             var methodReference = new MethodReference(reference.Name, reference.MethodReturnType.ReturnType, declaringType);
+            if (reference.HasGenericParameters)
+            {
+                foreach (var p in reference.GenericParameters)
+                {
+                    var gp=new GenericParameter(p.Name,reference);
+                    methodReference.GenericParameters.Add(gp);
+                }
+            }
             foreach (var parameterDefinition in reference.Parameters)
             {
                 methodReference.Parameters.Add(parameterDefinition);

--- a/PropertyChanged.Fody/MethodGenerifier.cs
+++ b/PropertyChanged.Fody/MethodGenerifier.cs
@@ -25,6 +25,13 @@ public partial class ModuleWeaver
                                 CallingConvention = self.CallingConvention,
                             };
 
+        if (self.HasGenericParameters)
+            foreach (var p in self.GenericParameters)
+            {
+                var gp = new GenericParameter(p.Name, self);
+                reference.GenericParameters.Add(gp);
+            }
+
         foreach (var parameter in self.Parameters)
         {
             reference.Parameters.Add(new ParameterDefinition(parameter.ParameterType));

--- a/PropertyChanged.Fody/MethodGenerifier.cs
+++ b/PropertyChanged.Fody/MethodGenerifier.cs
@@ -26,11 +26,9 @@ public partial class ModuleWeaver
                             };
 
         if (self.HasGenericParameters)
-            foreach (var p in self.GenericParameters)
-            {
-                var gp = new GenericParameter(p.Name, self);
-                reference.GenericParameters.Add(gp);
-            }
+        {
+            ImportGenericParameters(reference, self);
+        }
 
         foreach (var parameter in self.Parameters)
         {
@@ -40,4 +38,12 @@ public partial class ModuleWeaver
         return reference;
     }
 
+    internal static void ImportGenericParameters(IGenericParameterProvider imported, IGenericParameterProvider original)
+    {
+        var parameters = original.GenericParameters;
+        var importedParameters = imported.GenericParameters;
+
+        foreach (var t in parameters)
+            importedParameters.Add(new GenericParameter(t.Name, imported));
+    }
 }


### PR DESCRIPTION
Though not mentioned in wiki page, I found the code seems already had support for generic OnPropertyChanged BeforeAfter method which signature should be
`public void OnPropertyChanged<T>(string propertyName, T before, T after)`
But it would cause a method not found exception in runtime.

Managed to get it fixed, please take a look.
