### PR TITLE
Reverted a change that broke fody when used with NHibernate for us. W…

### DIFF
--- a/NuGet/PropertyChanged.Fody.nuspec
+++ b/NuGet/PropertyChanged.Fody.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.8">
-    <version>$version$-beta001</version>
+    <version>$version$-snfc</version>
     <developmentDependency>true</developmentDependency>
     <licenseUrl>http://www.opensource.org/licenses/mit-license.php</licenseUrl>
     <projectUrl>http://github.com/Fody/PropertyChanged</projectUrl>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Fork Notes
+
+This fork/branch was created to revert a change that broke Fody PropertyChanged when used with NHibernate for us. With the change Fody no longer used our custom equality check, which broke equality comparison on objects where we only had the Id (proxies).
+
+Attempts will be made to keep this fork up to date with the actual PropertyChanged repository, but there is no gaurantee that will actually happen. 
+
+USE AT YOUR OWN RISK.
+
+To future maintainers of this fork: In order to keep this fork as simple as possible keep rebasing it onto the base fork. Follow the instructions on this page if you need help: https://robots.thoughtbot.com/keeping-a-github-fork-updated, adapting as needed to your Git UI interface of choice.
+
 ## This is an add-in for [Fody](https://github.com/Fody/Fody/) 
 
 ![Icon](https://raw.github.com/Fody/PropertyChanged/master/Icons/package_icon.png)


### PR DESCRIPTION
…ith the now-removed changes - fody no longer used our custom equality check, which broke equality comparison on objects where we only had the Id (proxies).