### PR TITLE
Fix #259: Exception for properties referencing a generic type with equality comparers in another assembly

### DIFF
--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -108,7 +108,12 @@ public partial class ModuleWeaver
         }
         if (equalsMethod != null && typeReference.IsGenericInstance)
         {
-            equalsMethod = MakeGeneric(typeReference, equalsMethod);
+            var genericType = new GenericInstanceType(equalsMethod.DeclaringType);
+            foreach (var argument in ((GenericInstanceType)typeReference).GenericArguments)
+            {
+                genericType.GenericArguments.Add(argument);
+            }
+            equalsMethod = MakeGeneric(genericType, equalsMethod);
         }
         return equalsMethod;
     }

--- a/PropertyChangedTests/AssemblyWithBaseInDifferentModuleTests.cs
+++ b/PropertyChangedTests/AssemblyWithBaseInDifferentModuleTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using AssemblyWithBase.BaseWithEquals;
+using NUnit.Framework;
 
 
 [TestFixture]
@@ -41,6 +42,14 @@ public class AssemblyWithBaseInDifferentModuleTests
     {
         var instance = weaverHelper.Assembly.GetInstance("AssemblyWithBaseInDifferentModule.MultiTypes.ChildClass");
         EventTester.TestProperty(instance, false);
+    }
+
+    [Test]
+    public void GenericEquals()
+    {
+        var instance = weaverHelper.Assembly.GetInstance("AssemblyWithBaseInDifferentModule.BaseWithGenericProperty.Class");
+        EventTester.TestProperty(instance, true);
+        Assert.IsTrue(BaseClass1<int>.EqualsCalled);
     }
 
     [Test]

--- a/TestAssemblies/AssemblyWithBase/BaseWithEquals/BaseClass1.cs
+++ b/TestAssemblies/AssemblyWithBase/BaseWithEquals/BaseClass1.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace AssemblyWithBase.BaseWithEquals
+{
+    public class BaseClass1<T> : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public static bool EqualsCalled { get; set; }
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public static bool operator ==(BaseClass1<T> first, BaseClass1<T> second)
+        {
+            EqualsCalled = true;
+            return false;
+        }
+
+        public static bool operator !=(BaseClass1<T> first, BaseClass1<T> second)
+        {
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((BaseClass1<T>)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/TestAssemblies/AssemblyWithBaseInDifferentModule/BaseWithGenericProperty/Class.cs
+++ b/TestAssemblies/AssemblyWithBaseInDifferentModule/BaseWithGenericProperty/Class.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using AssemblyWithBase.BaseWithEquals;
+
+namespace AssemblyWithBaseInDifferentModule.BaseWithGenericProperty
+{
+    public class Class : INotifyPropertyChanged
+    {
+        private string property1;
+
+        public string Property1
+        {
+            get => property1;
+            set
+            {
+                property1 = value;
+                Property2 = new BaseClass1<int>();
+            }
+        }
+
+        public BaseClass1<int> Property2 { get; set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
Fixed an unhandled exception that occured while weaving, if a property was using a generic type from another assembly that implmented static bool Equals(T,T) or had == overwritten.
See #259 for details.

Basically the issue was that in TypeEqualityFinder.FindNamedMethod a wrong type was passed to MakeGeneric, resulting in a wrong DeclaringType in the returned method.

Also refer to Mono.Cecil test ImportCecilTests.ImportGenericMethod(). The test also uses an extension MakeGeneric which creates a new GenericInstanceType for the MethodReference.DeclaringType.
When doing the same in the PropertyChanged-solution, other unit test failed, so I just left it in FindNamedMethod.