### PR TITLE
allow for config option to check equality using base Equals or not

### DIFF
--- a/PropertyChanged.Fody/CheckForEqualityUsingBaseEqualsConfig.cs
+++ b/PropertyChanged.Fody/CheckForEqualityUsingBaseEqualsConfig.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+
+public partial class ModuleWeaver
+{
+    public bool CheckForEqualityUsingBaseEquals = true;
+
+    public void ResolveCheckForEqualityUsingBaseEqualsConfig()
+    {
+        var value = Config?.Attributes("CheckForEqualityUsingBaseEquals").FirstOrDefault();
+        if (value != null)
+        {
+            CheckForEqualityUsingBaseEquals = bool.Parse((string)value);
+        }
+    }
+}

--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -77,7 +77,7 @@ public class EqualityCheckWeaver
         var typeEqualityMethod = typeEqualityFinder.FindTypeEquality(targetType);
         if (typeEqualityMethod == null)
         {
-            if (targetType.SupportsCeq() && targetType.IsValueType)
+            if (targetType.SupportsCeq() && (targetType.IsValueType || !typeEqualityFinder.CheckForEqualityUsingBaseEquals))
             {
                 instructions.Prepend(
                     Instruction.Create(OpCodes.Ldarg_0),

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -22,6 +22,7 @@ public partial class ModuleWeaver
     {
         ResolveOnPropertyNameChangedConfig();
         ResolveCheckForEqualityConfig();
+        ResolveCheckForEqualityUsingBaseEqualsConfig();
         ResolveEventInvokerName();
         FindCoreReferences();
         FindInterceptor();

--- a/PropertyChangedTests/CheckForEqualityUsingBaseEqualsConfigTests.cs
+++ b/PropertyChangedTests/CheckForEqualityUsingBaseEqualsConfigTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Xml.Linq;
+using NUnit.Framework;
+
+[TestFixture]
+public class CheckForEqualityUsingBaseEqualsConfigTests
+{
+    [Test]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged CheckForEqualityUsingBaseEquals='false'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveCheckForEqualityUsingBaseEqualsConfig();
+        Assert.IsFalse(moduleWeaver.CheckForEqualityUsingBaseEquals);
+    }
+
+    [Test]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged CheckForEqualityUsingBaseEquals='true'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveCheckForEqualityUsingBaseEqualsConfig();
+        Assert.IsTrue(moduleWeaver.CheckForEqualityUsingBaseEquals);
+    }
+
+    [Test]
+    public void Default()
+    {
+        var moduleWeaver = new ModuleWeaver();
+        moduleWeaver.ResolveCheckForEqualityUsingBaseEqualsConfig();
+        Assert.IsTrue(moduleWeaver.CheckForEqualityUsingBaseEquals);
+    }
+}


### PR DESCRIPTION
* When this option is `true` (default), a child class will use the parent's equality check in the event that the parent overrides `==`. 
* When this option is `false`, a child class will use the default equality check (`OpCodes.Ceq`) in the event that the parent overrides `==`. 
