### PR TITLE
Reduce GC pressure

### DIFF
--- a/PropertyChanged.Fody/EventArgsCache.cs
+++ b/PropertyChanged.Fody/EventArgsCache.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+public class EventArgsCache
+{
+    public EventArgsCache(ModuleWeaver moduleWeaver)
+    {
+        this.moduleWeaver = moduleWeaver;
+        cacheTypeDefinition = new TypeDefinition(null, "<>PropertyChangedEventArgs", TypeAttributes.AutoClass | TypeAttributes.AutoLayout | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit | TypeAttributes.Class | TypeAttributes.NotPublic, moduleWeaver.ModuleDefinition.TypeSystem.Object);
+    }
+
+    public FieldReference GetEventArgsField(string propertyName)
+    {
+        if (!properties.TryGetValue(propertyName, out var field))
+        {
+            field = new FieldDefinition(propertyName, FieldAttributes.Assembly | FieldAttributes.Static | FieldAttributes.InitOnly, moduleWeaver.PropertyChangedEventArgsReference);
+            properties.Add(propertyName, field);
+        }
+
+        return field;
+    }
+
+    public void InjectType()
+    {
+        if (properties.Count == 0)
+            return;
+
+        var cctor = new MethodDefinition(".cctor", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.Static, moduleWeaver.ModuleDefinition.TypeSystem.Void);
+
+        foreach (var pair in properties.OrderBy(i => i.Key))
+        {
+            var propertyName = pair.Key;
+            var eventArgsField = pair.Value;
+
+            cacheTypeDefinition.Fields.Add(eventArgsField);
+
+            cctor.Body.Instructions.Append(
+                Instruction.Create(OpCodes.Ldstr, propertyName),
+                Instruction.Create(OpCodes.Newobj, moduleWeaver.PropertyChangedEventConstructorReference),
+                Instruction.Create(OpCodes.Stsfld, eventArgsField)
+            );
+        }
+
+        cctor.Body.Instructions.Append(
+            Instruction.Create(OpCodes.Ret)
+        );
+
+        cacheTypeDefinition.Methods.Add(cctor);
+        moduleWeaver.ModuleDefinition.Types.Add(cacheTypeDefinition);
+    }
+
+    readonly ModuleWeaver moduleWeaver;
+    TypeDefinition cacheTypeDefinition;
+    Dictionary<string, FieldDefinition> properties = new Dictionary<string, FieldDefinition>();
+}

--- a/PropertyChanged.Fody/EventArgsCacheInjector.cs
+++ b/PropertyChanged.Fody/EventArgsCacheInjector.cs
@@ -1,0 +1,12 @@
+﻿partial class ModuleWeaver
+{
+    public void InitEventArgsCache()
+    {
+        EventArgsCache = new EventArgsCache(this);
+    }
+
+    public void InjectEventArgsCache() 
+        => EventArgsCache.InjectType();
+
+    public EventArgsCache EventArgsCache;
+}

--- a/PropertyChanged.Fody/InstructionListExtensions.cs
+++ b/PropertyChanged.Fody/InstructionListExtensions.cs
@@ -15,9 +15,9 @@ public static class InstructionListExtensions
 
     public static void Append(this Collection<Instruction> collection, params Instruction[] instructions)
     {
-        for (var index = 0; index < instructions.Length; index++)
+        foreach (var instruction in instructions)
         {
-            collection.Insert(index, instructions[index]);
+            collection.Add(instruction);
         }
     }
 

--- a/PropertyChanged.Fody/MethodFinder.cs
+++ b/PropertyChanged.Fody/MethodFinder.cs
@@ -93,16 +93,36 @@ public partial class ModuleWeaver
     {
         methodDefinition = type.Methods
             .Where(x => (x.IsFamily || x.IsFamilyAndAssembly || x.IsPublic || x.IsFamilyOrAssembly) && EventInvokerNames.Contains(x.Name))
-            .OrderByDescending(definition => definition.Parameters.Count)
+            .OrderByDescending(GetInvokerPriority)
             .FirstOrDefault(x => IsBeforeAfterGenericMethod(x) || IsBeforeAfterMethod(x) || IsSingleStringMethod(x) || IsPropertyChangedArgMethod(x) || IsSenderPropertyChangedArgMethod(x));
         if (methodDefinition == null)
         {
             methodDefinition = type.Methods
                 .Where(x => EventInvokerNames.Contains(x.Name))
-                .OrderByDescending(definition => definition.Parameters.Count)
+                .OrderByDescending(GetInvokerPriority)
                 .FirstOrDefault(x => IsBeforeAfterGenericMethod(x) || IsBeforeAfterMethod(x) || IsSingleStringMethod(x) || IsPropertyChangedArgMethod(x) || IsSenderPropertyChangedArgMethod(x));
         }
         return methodDefinition != null;
+    }
+
+    static int GetInvokerPriority(MethodDefinition method)
+    {
+        if (IsBeforeAfterGenericMethod(method))
+            return 5;
+
+        if (IsBeforeAfterMethod(method))
+            return 4;
+
+        if (IsSenderPropertyChangedArgMethod(method))
+            return 3;
+
+        if (IsPropertyChangedArgMethod(method))
+            return 2;
+
+        if (IsSingleStringMethod(method))
+            return 1;
+
+        return 0;
     }
 
     public static InvokerTypes ClassifyInvokerMethod(MethodDefinition method)

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -15,7 +15,7 @@ public partial class ModuleWeaver
                 throw new WeavingException(message);
             }
 
-            var methodDefinition = GetMethodDefinition(targetType);
+            var methodDefinition = GetMethodDefinition(targetType, out _);
 
             return new EventInvokerMethod
             {
@@ -27,37 +27,48 @@ public partial class ModuleWeaver
 
         return new EventInvokerMethod
         {
-            MethodReference = InjectMethod(targetType, EventInvokerNames.First()).GetGeneric(),
-            InvokerType = InterceptorType,
+            MethodReference = InjectMethod(targetType, EventInvokerNames.First(), out var invokerType).GetGeneric(),
+            InvokerType = invokerType,
             IsVisibleFromChildren = true,
         };
     }
 
-    MethodDefinition GetMethodDefinition(TypeDefinition targetType)
+    MethodDefinition GetMethodDefinition(TypeDefinition targetType, out InvokerTypes invokerType)
     {
         var eventInvokerName = $"Inner{EventInvokerNames.First()}";
         var methodDefinition = targetType.Methods.FirstOrDefault(x => x.Name == eventInvokerName);
         if (methodDefinition?.Parameters.Count == 1 && methodDefinition.Parameters[0].ParameterType.FullName == "System.String")
         {
+            invokerType = InvokerTypes.String;
             return methodDefinition;
         }
-        return InjectMethod(targetType, eventInvokerName);
+
+        return InjectMethod(targetType, eventInvokerName, out invokerType);
     }
 
-    MethodDefinition InjectMethod(TypeDefinition targetType, string eventInvokerName)
+    MethodDefinition InjectMethod(TypeDefinition targetType, string eventInvokerName, out InvokerTypes invokerType)
     {
         var propertyChangedFieldDef = targetType.Fields
             .SingleOrDefault(x => IsPropertyChangedEventHandler(x.FieldType));
         if (propertyChangedFieldDef != null)
         {
             var propertyChangedField = propertyChangedFieldDef.GetGeneric();
-            return InjectNormal(targetType, eventInvokerName, propertyChangedField);
+
+            if (FoundInterceptor)
+            {
+                invokerType = InvokerTypes.String;
+                return InjectNormal(targetType, eventInvokerName, propertyChangedField);
+            }
+
+            invokerType = InvokerTypes.PropertyChangedArg;
+            return InjectEventArgsMethod(targetType, eventInvokerName, propertyChangedField);
         }
 
         var fsharpPropertyChangedFieldDef = targetType.Fields
             .SingleOrDefault(x => IsFsharpEventHandler(x.FieldType));
         if (fsharpPropertyChangedFieldDef != null)
         {
+            invokerType = InvokerTypes.String;
             return InjectFsharp(targetType, eventInvokerName, fsharpPropertyChangedFieldDef);
         }
 
@@ -110,6 +121,39 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Newobj, PropertyChangedEventConstructorReference));
+        instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));
+
+        instructions.Add(last);
+        method.Body.InitLocals = true;
+        targetType.Methods.Add(method);
+        return method;
+    }
+
+    MethodDefinition InjectEventArgsMethod(TypeDefinition targetType, string eventInvokerName, FieldReference propertyChangedField)
+    {
+        var method = new MethodDefinition(eventInvokerName, GetMethodAttributes(targetType), ModuleDefinition.TypeSystem.Void);
+        method.Parameters.Add(new ParameterDefinition("eventArgs", ParameterAttributes.None, PropertyChangedEventArgsReference));
+
+        var handlerVariable = new VariableDefinition(PropChangedHandlerReference);
+        method.Body.Variables.Add(handlerVariable);
+        var boolVariable = new VariableDefinition(ModuleDefinition.TypeSystem.Boolean);
+        method.Body.Variables.Add(boolVariable);
+
+        var instructions = method.Body.Instructions;
+
+        var last = Instruction.Create(OpCodes.Ret);
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldfld, propertyChangedField));
+        instructions.Add(Instruction.Create(OpCodes.Stloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldnull));
+        instructions.Add(Instruction.Create(OpCodes.Ceq));
+        instructions.Add(Instruction.Create(OpCodes.Stloc_1));
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_1));
+        instructions.Add(Instruction.Create(OpCodes.Brtrue_S, last));
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));
 
         instructions.Add(last);

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -102,8 +102,6 @@ public partial class ModuleWeaver
 
         var handlerVariable = new VariableDefinition(PropChangedHandlerReference);
         method.Body.Variables.Add(handlerVariable);
-        var boolVariable = new VariableDefinition(ModuleDefinition.TypeSystem.Boolean);
-        method.Body.Variables.Add(boolVariable);
 
         var instructions = method.Body.Instructions;
 
@@ -112,15 +110,12 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Ldfld, propertyChangedField));
         instructions.Add(Instruction.Create(OpCodes.Stloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
-        instructions.Add(Instruction.Create(OpCodes.Ldnull));
-        instructions.Add(Instruction.Create(OpCodes.Ceq));
-        instructions.Add(Instruction.Create(OpCodes.Stloc_1));
-        instructions.Add(Instruction.Create(OpCodes.Ldloc_1));
-        instructions.Add(Instruction.Create(OpCodes.Brtrue_S, last));
+        instructions.Add(Instruction.Create(OpCodes.Brfalse_S, last));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Newobj, PropertyChangedEventConstructorReference));
+        instructions.Add(Instruction.Create(OpCodes.Tail));
         instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));
 
         instructions.Add(last);
@@ -136,8 +131,6 @@ public partial class ModuleWeaver
 
         var handlerVariable = new VariableDefinition(PropChangedHandlerReference);
         method.Body.Variables.Add(handlerVariable);
-        var boolVariable = new VariableDefinition(ModuleDefinition.TypeSystem.Boolean);
-        method.Body.Variables.Add(boolVariable);
 
         var instructions = method.Body.Instructions;
 
@@ -146,14 +139,11 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Ldfld, propertyChangedField));
         instructions.Add(Instruction.Create(OpCodes.Stloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
-        instructions.Add(Instruction.Create(OpCodes.Ldnull));
-        instructions.Add(Instruction.Create(OpCodes.Ceq));
-        instructions.Add(Instruction.Create(OpCodes.Stloc_1));
-        instructions.Add(Instruction.Create(OpCodes.Ldloc_1));
-        instructions.Add(Instruction.Create(OpCodes.Brtrue_S, last));
+        instructions.Add(Instruction.Create(OpCodes.Brfalse_S, last));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
+        instructions.Add(Instruction.Create(OpCodes.Tail));
         instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));
 
         instructions.Add(last);

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -25,7 +25,9 @@ public partial class ModuleWeaver: BaseModuleWeaver
         ProcessOnChangedMethods();
         CheckForStackOverflow();
         FindComparisonMethods();
+        InitEventArgsCache();
         ProcessTypes();
+        InjectEventArgsCache();
         CleanAttributes();
     }
 

--- a/PropertyChanged.Fody/MsCoreReferenceFinder.cs
+++ b/PropertyChanged.Fody/MsCoreReferenceFinder.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 public partial class ModuleWeaver
 {
     public MethodReference PropertyChangedEventHandlerInvokeReference;
+    public TypeReference PropertyChangedEventArgsReference;
     public MethodReference PropertyChangedEventConstructorReference;
     public MethodReference ActionConstructorReference;
     public MethodReference ObjectConstructor;
@@ -68,6 +69,7 @@ public partial class ModuleWeaver
         PropChangedHandlerReference = ModuleDefinition.ImportReference(propChangedHandlerDefinition);
         PropertyChangedEventHandlerInvokeReference = ModuleDefinition.ImportReference(propChangedHandlerDefinition.Methods.First(x => x.Name == "Invoke"));
         var propChangedArgsDefinition = FindType("System.ComponentModel.PropertyChangedEventArgs");
+        PropertyChangedEventArgsReference = ModuleDefinition.ImportReference(propChangedArgsDefinition);
         PropertyChangedEventConstructorReference = ModuleDefinition.ImportReference(propChangedArgsDefinition.Methods.First(x => x.IsConstructor));
 
         var delegateDefinition = FindType("System.Delegate");

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -195,8 +195,7 @@ public class PropertyWeaver
     {
         return instructions.Insert(index,
                                    Instruction.Create(OpCodes.Ldarg_0),
-                                   Instruction.Create(OpCodes.Ldstr, property.Name),
-                                   Instruction.Create(OpCodes.Newobj, moduleWeaver.PropertyChangedEventConstructorReference),
+                                   Instruction.Create(OpCodes.Ldsfld, moduleWeaver.EventArgsCache.GetEventArgsField(property.Name)),
                                    CallEventInvoker(property));
     }
 
@@ -205,8 +204,7 @@ public class PropertyWeaver
         return instructions.Insert(index,
                                    Instruction.Create(OpCodes.Ldarg_0),
                                    Instruction.Create(OpCodes.Ldarg_0),
-                                   Instruction.Create(OpCodes.Ldstr, property.Name),
-                                   Instruction.Create(OpCodes.Newobj, moduleWeaver.PropertyChangedEventConstructorReference),
+                                   Instruction.Create(OpCodes.Ldsfld, moduleWeaver.EventArgsCache.GetEventArgsField(property.Name)),
                                    CallEventInvoker(property));
     }
 

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -72,4 +72,19 @@ public class AssemblyToProcessTests
         var instance = testResult.GetInstance("ClassWithIndirectImplementation");
         EventTester.TestProperty(instance, false);
     }
+
+    [Fact]
+    public void UseSingleEventInstance()
+    {
+        var instance = testResult.GetInstance("ClassWithNotifyPropertyChangedAttribute");
+
+        var argsList = new List<PropertyChangedEventArgs>();
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) => argsList.Add(args);
+
+        instance.Property1 = "a";
+        instance.Property1 = "b";
+
+        Assert.Equal(2, argsList.Count);
+        Assert.Same(argsList[0], argsList[1]);
+    }
 }

--- a/Tests/MethodFinderTest.cs
+++ b/Tests/MethodFinderTest.cs
@@ -126,4 +126,39 @@ public class MethodFinderTest
         {
         }
     }
+
+    [Theory]
+    [InlineData(nameof(MultipleInvokersStringFirst))]
+    [InlineData(nameof(ClassWithMultipleInvokersEventArgsFirst))]
+    public void PreferEventArgsOverString(string typeName)
+    {
+        var definitionToProcess = typeDefinition.NestedTypes.First(x => x.Name == typeName);
+        var methodReference = methodFinder.RecursiveFindEventInvoker(definitionToProcess);
+        Assert.NotNull(methodReference);
+        Assert.Equal("OnPropertyChanged", methodReference.MethodReference.Name);
+        Assert.Equal(nameof(PropertyChangedEventArgs), methodReference.MethodReference.Parameters.First().ParameterType.Name);
+        Assert.Equal(InvokerTypes.PropertyChangedArg, methodReference.InvokerType);
+    }
+
+    public class MultipleInvokersStringFirst
+    {
+        protected void OnPropertyChanged(string propertyName)
+        {
+        }
+
+        protected void OnPropertyChanged(PropertyChangedEventArgs eventArgs)
+        {
+        }
+    }
+
+    public class ClassWithMultipleInvokersEventArgsFirst
+    {
+        protected void OnPropertyChanged(PropertyChangedEventArgs eventArgs)
+        {
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+        }
+    }
 }


### PR DESCRIPTION
This PR aims to eliminate heap allocations when property change events are raised, as those tend to pile up in big projects. This should bring an overall performance improvement by reducing the time spent in GC.

This is achieved by injecting a static internal class named `<>PropertyChangedEventArgs` which has fields of `PropertyChangedEventArgs` instances. This is safe as `PropertyChangedEventArgs` is immutable. There is one field per distinct property name (if several classes have a `Foo` property, only one `Foo` event args field will be generated).

To support this, when an event invoker needs to be injected, this will inject a method with the  `void OnPropertyChanged(PropertyChangedEventArgs)` signature instead of `void OnPropertyChanged(string)`.

When multiple suitable event invoker methods are available in a type, preference will be given to overloads with an `PropertyChangedEventArgs` argument (while keeping the previous behavior of giving preference to methods with before/after parameters). Also, if an interceptor is provided, the code falls back to the old behavior.

Of course, if an invoker method is already provided, it will be used. But providing an overload with a `PropertyChangedEventArgs` parameter or relying on the default injection will now completely eliminate all heap allocations when the setters are called.

---

To summarize, the following code:

```C#
[AddINotifyPropertyChangedInterface]
public class Person
{
    public string Name { get; set; }
}
```

Will get compiled to this:

```C#
public class Person : INotifyPropertyChanged
{
    private string <Name>k__BackingField;

    public string Name
    {
        get => <Name>k__BackingField;
        set
        {
            if (string.Equals(value, <Name>k__BackingField, StringComparison.Ordinal))
                return;

            <Name>k__BackingField = value;
            OnPropertyChanged(<>PropertyChangedEventArgs.Name);
        }
    }

    public virtual void OnPropertyChanged(PropertyChangedEventArgs eventArgs)
    {
        PropertyChanged?.Invoke(this, eventArgs);
    }

    public event PropertyChangedEventHandler PropertyChanged;
}

internal static class <>PropertyChangedEventArgs
{
    internal static readonly PropertyChangedEventArgs Name = new PropertyChangedEventArgs("Name");
}
```