### PR TITLE
Don't expose injected methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ public class Person : INotifyPropertyChanged
             if (value != givenNames)
             {
                 givenNames = value;
-                OnPropertyChanged("GivenNames");
-                OnPropertyChanged("FullName");
+                OnPropertyChanged(InternalEventArgsCache.GivenNames);
+                OnPropertyChanged(InternalEventArgsCache.FullName);
             }
         }
     }
@@ -85,20 +85,30 @@ public class Person : INotifyPropertyChanged
             if (value != familyName)
             {
                 familyName = value;
-                OnPropertyChanged("FamilyName");
-                OnPropertyChanged("FullName");
+                OnPropertyChanged(InternalEventArgsCache.FamilyName);
+                OnPropertyChanged(InternalEventArgsCache.FullName);
             }
         }
     }
 
     public string FullName => $"{GivenNames} {FamilyName}";
 
-    public virtual void OnPropertyChanged(string propertyName)
+    protected void OnPropertyChanged(PropertyChangedEventArgs eventArgs)
     {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        PropertyChanged?.Invoke(this, eventArgs);
     }
 }
+
+internal static class InternalEventArgsCache
+{
+    internal static readonly FamilyName = new PropertyChangedEventArgs("FamilyName");
+    internal static readonly FullName = new PropertyChangedEventArgs("FullName");
+    internal static readonly GivenNames = new PropertyChangedEventArgs("GivenNames");
+}
 ```
+
+(the actual injected type and method names are different)
+
 ---
 
 


### PR DESCRIPTION
This is something that got me thinking since my previous PR: I don't think injected methods should be exposed to the outside world, for several reasons:

 - Foreign code has no business calling `OnPropertyChanged` on a different class.
 - People shouldn't extend weaved classes and make use of injected methods, as it seems very brittle, and the development workflow would be... weird at best. I really hope no one actually relies on this.
 - If someone really _needs_ to expose an event invoker for some reason, he should declare it by himself and not rely on injection, to ensure API stability. Plus, it makes for a better workflow than the previous point.
 - #318 already made a breaking change by changing the signature of the default injected method anyway.

So, this PR changes the injected method signatures from `public virtual void OnPropertyChanged(...)` to `protected void <>OnPropertyChanged(...)` (from `public` to `protected`, removes `virtual` and uses a name that can't cause collisions).

It also updates the readme to better reflect the generated code after #318.
