### PR TITLE
Fix #329: Ignore base types that can't be resolved

### DIFF
--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -77,7 +78,18 @@ public class EqualityCheckWeaver
         var typeEqualityMethod = propertyData.EqualsMethod;
         if (typeEqualityMethod == null)
         {
-            if (targetType.SupportsCeq() && (targetType.IsValueType || !typeEqualityFinder.CheckForEqualityUsingBaseEquals))
+            var supportsCeq = false;
+
+            try
+            {
+                supportsCeq = targetType.SupportsCeq();
+            }
+            catch (Exception ex)
+            {
+                typeEqualityFinder.LogWarning($"Ignoring Ceq of type {targetType.FullName} => {ex.Message}");
+            }
+
+            if (supportsCeq && (targetType.IsValueType || !typeEqualityFinder.CheckForEqualityUsingBaseEquals))
             {
                 instructions.Prepend(
                     Instruction.Create(OpCodes.Ldarg_0),

--- a/PropertyChanged.Fody/NotifyInterfaceFinder.cs
+++ b/PropertyChanged.Fody/NotifyInterfaceFinder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Mono.Cecil;
 
@@ -20,7 +21,15 @@ public partial class ModuleWeaver
         }
         else
         {
-            typeDefinition = Resolve(typeReference);
+            try
+            {
+                typeDefinition = Resolve(typeReference);
+            }
+            catch (Exception ex)
+            {
+                LogWarning($"Ignoring type {fullName} in type hierarchy => {ex.Message}");
+                return false;
+            }
         }
 
         foreach (var interfaceImplementation in typeDefinition.Interfaces)

--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
@@ -80,7 +81,17 @@ public partial class ModuleWeaver
 
     MethodReference GetStaticEquality(TypeReference typeReference)
     {
-        var typeDefinition = Resolve(typeReference);
+        TypeDefinition typeDefinition;
+        try
+        {
+            typeDefinition = Resolve(typeReference);
+        }
+        catch (Exception ex)
+        {
+            LogWarning($"Ignoring static equality of type {typeReference.FullName} => {ex.Message}");
+            return null;
+        }
+
         if (typeDefinition.IsInterface)
         {
             return null;


### PR DESCRIPTION
e.g. because they are defined in a mixed-mode assembly.