### PR TITLE
Equality comparers not detected in class hierarchies

### DIFF
--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -21,15 +21,19 @@ public partial class ModuleWeaver
             .First(x => x.Name == "Ordinal")
             .Constant;
 
-        foreach (var node in NotifyNodes)
-        {
-            foreach (var data in node.PropertyDatas)
-            {
-                data.EqualsMethod = FindTypeEquality(data);
-            }
-        }
+        NotifyNodes.ForEach(FindComparisonMethods);
 
         methodCache = null;
+    }
+
+    void FindComparisonMethods(TypeNode node)
+    {
+        foreach (var data in node.PropertyDatas)
+        {
+            data.EqualsMethod = FindTypeEquality(data);
+        }
+
+        node.Nodes.ForEach(FindComparisonMethods);
     }
 
     MethodReference FindTypeEquality(PropertyData propertyData)

--- a/TestAssemblies/AssemblyWithBaseInDifferentModule/Hierarchy/ChildClass.cs
+++ b/TestAssemblies/AssemblyWithBaseInDifferentModule/Hierarchy/ChildClass.cs
@@ -1,0 +1,20 @@
+﻿namespace AssemblyWithBaseInDifferentModule.Hierarchy
+{
+    using AssemblyWithBase.StaticEquals;
+
+    public class ChildClass : StaticEquals
+    {
+        private string property1;
+        public string Property1
+        {
+            get => property1;
+            set
+            {
+                property1 = value;
+                Property2 = new BaseClass();
+            }
+        }
+
+        public BaseClass Property2 { get; set; }
+    }
+}

--- a/TestAssemblies/AssemblyWithBaseInDifferentModule/Hierarchy/StaticEquals.cs
+++ b/TestAssemblies/AssemblyWithBaseInDifferentModule/Hierarchy/StaticEquals.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace AssemblyWithBaseInDifferentModule.Hierarchy
+{
+    public class StaticEquals : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Tests/AssemblyWithBaseInDifferentModuleTests.cs
+++ b/Tests/AssemblyWithBaseInDifferentModuleTests.cs
@@ -74,6 +74,17 @@ public class AssemblyWithBaseInDifferentModuleTests
     }
 
     [Fact]
+    public void StaticEquals_Hierarchy()
+    {
+        Weave(true);
+        var instance = testResult.GetInstance("AssemblyWithBaseInDifferentModule.Hierarchy.ChildClass");
+        EventTester.TestProperty(instance, true);
+        Assert.NotNull(instance.Property2);
+        Assert.True(instance.Property2.StaticEqualsCalled);
+        instance.Property2.StaticEqualsCalled = false;
+    }
+
+    [Fact]
     public void GenericStaticEquals()
     {
         Weave(false);


### PR DESCRIPTION
In my last PR (#310) I've introduced a bug:
Equality comparers in class hierarchies are not properly detected, as the child nodes of NotifyNodes weren't processed.

Here the fix for it.