### PR TITLE
Fix the injected invoker name not being recognized

### DIFF
--- a/PropertyChanged.Fody/EventInvokerNameResolver.cs
+++ b/PropertyChanged.Fody/EventInvokerNameResolver.cs
@@ -13,7 +13,8 @@ public partial class ModuleWeaver
         "RaisePropertyChanged",
         "NotifyPropertyChanged",
         "NotifyChanged",
-        "raisePropertyChanged"
+        "raisePropertyChanged",
+        injectedEventInvokerName
     };
 
     public void ResolveEventInvokerName()
@@ -28,9 +29,12 @@ public partial class ModuleWeaver
             .Select(x => x.Trim())
             .Where(x => x.Length > 0)
             .ToList();
+
         if (!EventInvokerNames.Any())
         {
             throw new WeavingException("EventInvokerNames contained no items.");
         }
+
+        EventInvokerNames.Add(injectedEventInvokerName);
     }
 }

--- a/Tests/EventInvokerNamesConfigTests.cs
+++ b/Tests/EventInvokerNamesConfigTests.cs
@@ -9,11 +9,13 @@ public class EventInvokerNamesConfigTests
         var xElement = XElement.Parse("<PropertyChanged EventInvokerNames='A,B'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ResolveEventInvokerName();
-        Assert.Contains("A", moduleWeaver.EventInvokerNames);
-        Assert.Contains("B", moduleWeaver.EventInvokerNames);
 
-        // Custom values should override the defaults
-        Assert.DoesNotContain("OnPropertyChanged", moduleWeaver.EventInvokerNames);
+        // Custom values should override the defaults, but the injected method name should always be included
+
+        Assert.Equal(new[]
+        {
+            "A", "B", "<>OnPropertyChanged"
+        }, moduleWeaver.EventInvokerNames);
     }
 
     [Fact]
@@ -28,5 +30,6 @@ public class EventInvokerNamesConfigTests
         Assert.Contains("NotifyPropertyChanged", moduleWeaver.EventInvokerNames);
         Assert.Contains("NotifyChanged", moduleWeaver.EventInvokerNames);
         Assert.Contains("raisePropertyChanged", moduleWeaver.EventInvokerNames);
+        Assert.Contains("<>OnPropertyChanged", moduleWeaver.EventInvokerNames);
     }
 }


### PR DESCRIPTION
The issue arises when a base class in a different project gets its event invoker injected.
Derived classes in different projects didn't recognize the method as the event invoker.
This commit makes sure the injected event invoker method is always included in the list of methods to consider.

Detailed issue description [here](https://github.com/Fody/PropertyChanged/issues/333#issuecomment-381766005).

This closes #333 and _maybe_ even #316 .