### PR TITLE
Support for explicit interface implementations

### DIFF
--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -126,4 +126,18 @@ public static class CecilExtensions
     {
         return attributes.Any(attribute => attribute.Constructor.DeclaringType.FullName == attributeName);
     }
+
+    public static IEnumerable<TypeReference> GetAllInterfaces(this TypeDefinition type)
+    {
+        while (type != null)
+        {
+            if (type.HasInterfaces)
+            {
+                foreach (var iface in type.Interfaces)
+                    yield return iface.InterfaceType;
+            }
+
+            type = type.BaseType?.Resolve();
+        }
+    }
 }

--- a/PropertyChanged.Fody/EventInvokerNameResolver.cs
+++ b/PropertyChanged.Fody/EventInvokerNameResolver.cs
@@ -13,7 +13,7 @@ public partial class ModuleWeaver
         "RaisePropertyChanged",
         "NotifyPropertyChanged",
         "NotifyChanged",
-        "raisePropertyChanged",
+        "ReactiveUI.IReactiveObject.RaisePropertyChanged",
         injectedEventInvokerName
     };
 

--- a/PropertyChanged.Fody/MethodFinder.cs
+++ b/PropertyChanged.Fody/MethodFinder.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Fody;
 using Mono.Cecil;
 
 public partial class ModuleWeaver
@@ -14,11 +13,11 @@ public partial class ModuleWeaver
             {
                 var methodReference = MakeGeneric(node.TypeDefinition.BaseType, eventInvoker.MethodReference);
                 eventInvoker = new EventInvokerMethod
-                {
-                    InvokerType = eventInvoker.InvokerType,
-                    MethodReference = methodReference,
-                    IsVisibleFromChildren = eventInvoker.IsVisibleFromChildren
-                };
+                                   {
+                                       InvokerType = eventInvoker.InvokerType,
+                                       MethodReference = methodReference,
+                                       IsVisibleFromChildren = eventInvoker.IsVisibleFromChildren
+                                   };
             }
         }
         else
@@ -28,17 +27,25 @@ public partial class ModuleWeaver
 
         if (!eventInvoker.IsVisibleFromChildren)
         {
-            var baseExplicitInterfaceEventInvoker = RecursiveFindExplicitInterfaceEventInvoker(node, eventInvoker);
-            if (baseExplicitInterfaceEventInvoker != null)
+            var methodName = eventInvoker.MethodReference.Name;
+            var viewModelBaseType = node.TypeDefinition.BaseType.Resolve();
+            
+            // WARN: Not finished yet.
+            // TODO: Support nested hierarchies.
+            foreach (var implementation in viewModelBaseType.Interfaces)
             {
-                eventInvoker = baseExplicitInterfaceEventInvoker;
-            }
-            else
-            {
-                var error = $"Cannot use '{eventInvoker.MethodReference.FullName}' in " +
-                            $"'{node.TypeDefinition.FullName}' since that method is not " +
-                             "visible from the child class.";
-                throw new WeavingException(error);
+                var interfaceType = implementation.InterfaceType;
+                var interfaceResolution = interfaceType.Resolve();
+                var method = interfaceResolution.Methods.FirstOrDefault(x => methodName.Contains(x.Name));
+                if (method == null) continue;
+
+                var methodReference = MakeGeneric(interfaceType, method);
+                eventInvoker = new EventInvokerMethod
+                {
+                    IsVisibleFromChildren = eventInvoker.IsVisibleFromChildren,
+                    InvokerType = eventInvoker.InvokerType,
+                    MethodReference = methodReference
+                };
             }
         }
         
@@ -47,32 +54,6 @@ public partial class ModuleWeaver
         {
             ProcessChildNode(childNode, eventInvoker);
         }
-    }
-
-    static EventInvokerMethod RecursiveFindExplicitInterfaceEventInvoker(TypeNode node, EventInvokerMethod eventInvoker)
-    {
-        var methodName = eventInvoker.MethodReference.Name;
-        var viewModelBaseType = node.TypeDefinition.BaseType.Resolve();
-    
-        // WARN: Not finished yet.
-        // TODO: Support nested hierarchies.
-        foreach (var implementation in viewModelBaseType.Interfaces)
-        {
-            var interfaceType = implementation.InterfaceType;
-            var interfaceResolution = interfaceType.Resolve();
-            var method = interfaceResolution.Methods.FirstOrDefault(x => methodName.Contains(x.Name));
-            if (method == null) continue;
-
-            var methodReference = MakeGeneric(interfaceType, method);
-            return new EventInvokerMethod
-            {
-                IsVisibleFromChildren = eventInvoker.IsVisibleFromChildren,
-                InvokerType = eventInvoker.InvokerType,
-                MethodReference = methodReference
-            };
-        }
-        
-        return null;
     }
 
     public EventInvokerMethod RecursiveFindEventInvoker(TypeDefinition typeDefinition)

--- a/PropertyChanged.Fody/MethodFinder.cs
+++ b/PropertyChanged.Fody/MethodFinder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Fody;
 using Mono.Cecil;
 
 public partial class ModuleWeaver
@@ -27,29 +28,12 @@ public partial class ModuleWeaver
 
         if (!eventInvoker.IsVisibleFromChildren)
         {
-            var methodName = eventInvoker.MethodReference.Name;
-            var viewModelBaseType = node.TypeDefinition.BaseType.Resolve();
-            
-            // WARN: Not finished yet.
-            // TODO: Support nested hierarchies.
-            foreach (var implementation in viewModelBaseType.Interfaces)
-            {
-                var interfaceType = implementation.InterfaceType;
-                var interfaceResolution = interfaceType.Resolve();
-                var method = interfaceResolution.Methods.FirstOrDefault(x => methodName.Contains(x.Name));
-                if (method == null) continue;
-
-                var methodReference = MakeGeneric(interfaceType, method);
-                eventInvoker = new EventInvokerMethod
-                {
-                    IsVisibleFromChildren = eventInvoker.IsVisibleFromChildren,
-                    InvokerType = eventInvoker.InvokerType,
-                    MethodReference = methodReference
-                };
-            }
+            var error = $"Cannot use '{eventInvoker.MethodReference.FullName}' in '{node.TypeDefinition.FullName}' since that method is not visible from the child class.";
+            throw new WeavingException(error);
         }
         
         node.EventInvoker = eventInvoker;
+
         foreach (var childNode in node.Nodes)
         {
             ProcessChildNode(childNode, eventInvoker);
@@ -65,7 +49,8 @@ public partial class ModuleWeaver
         {
             typeDefinitions.Push(currentTypeDefinition);
 
-            if (FindEventInvokerMethodDefinition(currentTypeDefinition, out methodDefinition))
+            methodDefinition = FindEventInvokerMethodDefinition(currentTypeDefinition);
+            if (methodDefinition != null)
             {
                 break;
             }
@@ -93,10 +78,25 @@ public partial class ModuleWeaver
 
     EventInvokerMethod FindEventInvokerMethod(TypeDefinition type)
     {
-        if (!FindEventInvokerMethodDefinition(type, out var methodDefinition))
+        var methodDefinition = FindEventInvokerMethodDefinition(type);
+
+        if (methodDefinition == null || methodDefinition.IsPrivate)
         {
-            return null;
+            var overriddenMethod = FindExplicitImplementation(type);
+            if (overriddenMethod != null)
+            {
+                return new EventInvokerMethod
+                {
+                    MethodReference = ModuleDefinition.ImportReference(overriddenMethod).GetGeneric(),
+                    IsVisibleFromChildren = true,
+                    InvokerType = ClassifyInvokerMethod(overriddenMethod)
+                };
+            }
         }
+
+        if (methodDefinition == null)
+            return null;
+
         var methodReference = ModuleDefinition.ImportReference(methodDefinition);
         return new EventInvokerMethod
         {
@@ -106,23 +106,35 @@ public partial class ModuleWeaver
         };
     }
 
-    bool FindEventInvokerMethodDefinition(TypeDefinition type, out MethodDefinition methodDefinition)
+    MethodDefinition FindEventInvokerMethodDefinition(TypeDefinition type)
     {
-        methodDefinition = type.Methods
+        var methodDefinition = type.Methods
             .Where(x => (x.IsFamily || x.IsFamilyAndAssembly || x.IsPublic || x.IsFamilyOrAssembly) && EventInvokerNames.Contains(x.Name))
             .OrderByDescending(GetInvokerPriority)
-            .FirstOrDefault(x => IsBeforeAfterGenericMethod(x) || IsBeforeAfterMethod(x) || IsSingleStringMethod(x) || IsPropertyChangedArgMethod(x) || IsSenderPropertyChangedArgMethod(x));
+            .FirstOrDefault(IsEventInvokerMethod);
+
         if (methodDefinition == null)
         {
             methodDefinition = type.Methods
                 .Where(x => EventInvokerNames.Contains(x.Name))
                 .OrderByDescending(GetInvokerPriority)
-                .FirstOrDefault(x => IsBeforeAfterGenericMethod(x) || IsBeforeAfterMethod(x) || IsSingleStringMethod(x) || IsPropertyChangedArgMethod(x) || IsSenderPropertyChangedArgMethod(x));
+                .FirstOrDefault(IsEventInvokerMethod);
         }
-        return methodDefinition != null;
+
+        return methodDefinition;
     }
 
-    static int GetInvokerPriority(MethodDefinition method)
+    MethodReference FindExplicitImplementation(TypeDefinition type)
+    {
+        return type.GetAllInterfaces()
+            .Select(i => i.Resolve())
+            .Where(i => i != null && i.IsPublic)
+            .SelectMany(i => i.Methods.Where(m => EventInvokerNames.Contains($"{i.FullName}.{m.Name}")))
+            .OrderByDescending(GetInvokerPriority)
+            .FirstOrDefault(IsEventInvokerMethod);
+    }
+
+    static int GetInvokerPriority(MethodReference method)
     {
         if (IsBeforeAfterGenericMethod(method))
             return 5;
@@ -142,7 +154,7 @@ public partial class ModuleWeaver
         return 0;
     }
 
-    public static InvokerTypes ClassifyInvokerMethod(MethodDefinition method)
+    public static InvokerTypes ClassifyInvokerMethod(MethodReference method)
     {
         if (IsSenderPropertyChangedArgMethod(method))
         {
@@ -164,7 +176,16 @@ public partial class ModuleWeaver
         return InvokerTypes.String;
     }
 
-    public static bool IsSenderPropertyChangedArgMethod(MethodDefinition method)
+    static bool IsEventInvokerMethod(MethodReference method)
+    {
+        return IsBeforeAfterGenericMethod(method)
+               || IsBeforeAfterMethod(method)
+               || IsSingleStringMethod(method)
+               || IsPropertyChangedArgMethod(method)
+               || IsSenderPropertyChangedArgMethod(method);
+    }
+
+    public static bool IsSenderPropertyChangedArgMethod(MethodReference method)
     {
         var parameters = method.Parameters;
         return parameters.Count == 2
@@ -172,21 +193,21 @@ public partial class ModuleWeaver
                && parameters[1].ParameterType.FullName == "System.ComponentModel.PropertyChangedEventArgs";
     }
 
-    public static bool IsPropertyChangedArgMethod(MethodDefinition method)
+    public static bool IsPropertyChangedArgMethod(MethodReference method)
     {
         var parameters = method.Parameters;
         return parameters.Count == 1
                && parameters[0].ParameterType.FullName == "System.ComponentModel.PropertyChangedEventArgs";
     }
 
-    public static bool IsSingleStringMethod(MethodDefinition method)
+    public static bool IsSingleStringMethod(MethodReference method)
     {
         var parameters = method.Parameters;
         return parameters.Count == 1
                && parameters[0].ParameterType.FullName == "System.String";
     }
 
-    public static bool IsBeforeAfterMethod(MethodDefinition method)
+    public static bool IsBeforeAfterMethod(MethodReference method)
     {
         var parameters = method.Parameters;
         return parameters.Count == 3
@@ -195,7 +216,7 @@ public partial class ModuleWeaver
                && parameters[2].ParameterType.FullName == "System.Object";
     }
 
-    public static bool IsBeforeAfterGenericMethod(MethodDefinition method)
+    public static bool IsBeforeAfterGenericMethod(MethodReference method)
     {
         var parameters = method.Parameters;
         return parameters.Count == 3

--- a/TestAssemblies/AssemblyToProcess/SupportedLibraries/BaseClasses.cs
+++ b/TestAssemblies/AssemblyToProcess/SupportedLibraries/BaseClasses.cs
@@ -205,14 +205,23 @@ namespace Jounce.Core.ViewModel
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveObject : INotifyPropertyChanged
+    public interface IReactiveObject : INotifyPropertyChanged 
     {
-        public bool BaseNotifyCalled { get; set; }
-        public event PropertyChangedEventHandler PropertyChanged;
-        public virtual void raisePropertyChanged(string propertyName)
+        void RaisePropertyChanged(PropertyChangedEventArgs args);
+    }
+    
+    public class ReactiveObject : IReactiveObject
+    {
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
         {
-            BaseNotifyCalled = true;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            changed?.Invoke(this, args);
+        }
+
+        event PropertyChangedEventHandler changed;
+        public event PropertyChangedEventHandler PropertyChanged
+        {
+            add => changed += value;
+            remove => changed -= value;
         }
     }
 }

--- a/TestAssemblies/AssemblyToProcess/SupportedLibraries/ClassReactiveUI.cs
+++ b/TestAssemblies/AssemblyToProcess/SupportedLibraries/ClassReactiveUI.cs
@@ -4,3 +4,8 @@ public class ClassReactiveUI : ReactiveObject
 {
     public string Property1 { get; set; }
 }
+
+public class ClassReactiveUI2 : ClassReactiveUI
+{
+    public string Property2 { get; set; }
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -91,15 +91,16 @@ public class AssemblyToProcessTests
     [Fact]
     public void SupportedLibrariesClassReactiveUI()
     {
-        var instance = testResult.GetInstance("ClassReactiveUI");
+        var instance = testResult.GetInstance("ClassReactiveUI2");
         
         var argsList = new List<PropertyChangedEventArgs>();
         ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) => argsList.Add(args);
 
         instance.Property1 = "a";
-        instance.Property1 = "b";
+        instance.Property2 = "b";
         
         Assert.Equal(2, argsList.Count);
-        Assert.Same(argsList[0], argsList[1]);
+        Assert.Equal("Property1", argsList[0].PropertyName);
+        Assert.Equal("Property2", argsList[1].PropertyName);
     }
 }

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -87,4 +87,19 @@ public class AssemblyToProcessTests
         Assert.Equal(2, argsList.Count);
         Assert.Same(argsList[0], argsList[1]);
     }
+
+    [Fact]
+    public void SupportedLibrariesClassReactiveUI()
+    {
+        var instance = testResult.GetInstance("ClassReactiveUI");
+        
+        var argsList = new List<PropertyChangedEventArgs>();
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) => argsList.Add(args);
+
+        instance.Property1 = "a";
+        instance.Property1 = "b";
+        
+        Assert.Equal(2, argsList.Count);
+        Assert.Same(argsList[0], argsList[1]);
+    }
 }

--- a/Tests/EventInvokerNamesConfigTests.cs
+++ b/Tests/EventInvokerNamesConfigTests.cs
@@ -29,7 +29,7 @@ public class EventInvokerNamesConfigTests
         Assert.Contains("RaisePropertyChanged", moduleWeaver.EventInvokerNames);
         Assert.Contains("NotifyPropertyChanged", moduleWeaver.EventInvokerNames);
         Assert.Contains("NotifyChanged", moduleWeaver.EventInvokerNames);
-        Assert.Contains("raisePropertyChanged", moduleWeaver.EventInvokerNames);
+        Assert.Contains("ReactiveUI.IReactiveObject.RaisePropertyChanged", moduleWeaver.EventInvokerNames);
         Assert.Contains("<>OnPropertyChanged", moduleWeaver.EventInvokerNames);
     }
 }


### PR DESCRIPTION
This PR adds support for explicit interface implementations to PropertyChanged.Fody. The current behavior is, that if Fody finds a method that is hidden from derived classes, it begins to panic and says: `Cannot use '{MethodReference.FullName}' in '{TypeDefinition.FullName}' since that method is not visible from the child class.`

Due to this, one could hardly use this awesome library with [ReactiveUI MVVM framework](https://github.com/reactiveui/ReactiveUI/blob/74b25861184ce59f2e1e890efa0faf2324991d45/src/ReactiveUI/ReactiveObject.cs#L67) - ReactiveUI's [ReactiveObject](https://github.com/reactiveui/ReactiveUI/blob/74b25861184ce59f2e1e890efa0faf2324991d45/src/ReactiveUI/ReactiveObject.cs#L62) uses explicit interface implementation, RaisePropertyChanged method is hidden:
```csharp
public class ReactiveObject {
  void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args) {
    PropertyChangedEventManager.DeliverEvent(this, args);
  }
}
```
Also ReactiveObjects have a custom PropertyChanged event implementation:
```csharp
public class ReactiveObject {
  public event PropertyChangedEventHandler PropertyChanged {
    add { PropertyChangedEventManager.AddHandler(this, value); }
    remove { PropertyChangedEventManager.RemoveHandler(this, value); }
  }
}
```
The first commit in this PR fixes the issue, so now PropertyChanged.Fody plays well with ReactiveUI framework – see the unit tests with an updated base class for ReactiveUI. But current code doesn't support multiple levels of inheritance – it scans only interfaces that a base class implements. Need to mention, that I am not an expert in Mono.Cecil at all, and any help from respectful contributors and maintainers would be highly appreciated. Thanks in advance.

These are the plans:
- [x] Add support for ReactiveUI and ReactiveObjects
- [x] Update tests to use the latest ReactiveUI version base class
- [x] Support multiple levels of inheritance
- [x] Write tests to ensure Fody always plays well with explicit implementations