### PR TITLE
Fix GetPropertyChangedAddMethods logic

### DIFF
--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -57,7 +57,7 @@ public partial class ModuleWeaver
 
         if (addMethods.Count > 1)
         {
-            throw new WeavingException("Found more than one PropertyChangedAddMethod");
+            throw new WeavingException("Found more than one PropertyChanged event");
         }
 
         var fieldReferences = addMethods.Single().Body.Instructions

--- a/PropertyChanged.Fody/PropertyChangedAddMethodFinder.cs
+++ b/PropertyChanged.Fody/PropertyChangedAddMethodFinder.cs
@@ -7,9 +7,17 @@ public static class PropertyChangedAddMethodFinder
 {
     public static IEnumerable<MethodDefinition> GetPropertyChangedAddMethods(this TypeDefinition targetType)
     {
+        var foundExplicit = false;
+
         foreach (var method in targetType.Methods.Where(i => i.Overrides.Any(o => o.FullName == "System.Void System.ComponentModel.INotifyPropertyChanged::add_PropertyChanged(System.ComponentModel.PropertyChangedEventHandler)")))
         {
+            foundExplicit = true;
             yield return method;
+        }
+
+        if (foundExplicit)
+        {
+            yield break;
         }
 
         foreach (var method in targetType.Events.Where(i => i.Name == nameof(INotifyPropertyChanged.PropertyChanged)))

--- a/Tests/MethodInjectorTests.cs
+++ b/Tests/MethodInjectorTests.cs
@@ -46,6 +46,16 @@ public class MethodInjectorTests
     }
 
     [Fact]
+    public void ShouldNotConfuseExplicitImplWithUnrelatedEvent()
+    {
+        var type = methodInjector.ModuleDefinition.GetType(typeof(ClassWithExplicitImplAndPropertyChangedEvent).FullName, true).Resolve();
+        var field = methodInjector.GetEventHandlerField(type);
+
+        Assert.NotNull(field);
+        Assert.Equal(ClassWithExplicitImplAndPropertyChangedEvent.ExpectedFieldName, field.Name);
+    }
+
+    [Fact]
     public void ShouldFindCorrectHandlerFieldInClassThatReimplementsInterface()
     {
         var type = methodInjector.ModuleDefinition.GetType(typeof(ClassThatReimplementsInterface).FullName, true).Resolve();
@@ -118,6 +128,26 @@ public class MethodInjectorTests
 
     class ClassWithMultipleHandlerFieldsExplicitImpl : INotifyPropertyChanged
     {
+        event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
+        {
+            add => Second += value;
+            remove => Second -= value;
+        }
+
+        PropertyChangedEventHandler First;
+        PropertyChangedEventHandler Second;
+        PropertyChangedEventHandler Third;
+        public const string ExpectedFieldName = nameof(Second);
+    }
+
+    class ClassWithExplicitImplAndPropertyChangedEvent : INotifyPropertyChanged
+    {
+        event PropertyChangedEventHandler PropertyChanged
+        {
+            add => First += value;
+            remove => First -= value;
+        }
+
         event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
         {
             add => Second += value;


### PR DESCRIPTION
I believe a *subtle* regression has been introduced in 8465c68: when there is an explicit event implementation, then an additional `PropertyChanged` event should be ignored.

Yeah, that's a *totally* implausible edge case, but here's the fix anyway (don't even bother to do a release just for that one).