### PR TITLE
Set AllowMultiple = true for FilterTypeAttribute

### DIFF
--- a/PropertyChanged/FilterTypeAttribute.cs
+++ b/PropertyChanged/FilterTypeAttribute.cs
@@ -8,7 +8,7 @@ namespace PropertyChanged
     /// weaving process. These filters are Regex based and
     /// are matched against the Type.FullName
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly)]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class FilterTypeAttribute : Attribute
     {
         /// <summary>

--- a/TestAssemblies/AssemblyWithTypeFilter/AssemblyInfo.cs
+++ b/TestAssemblies/AssemblyWithTypeFilter/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using PropertyChanged;
 
 [assembly: FilterType("PropertyChangedTest.")]
+[assembly: FilterType("PropertyChangedTestWithDifferentNamespace.")]

--- a/TestAssemblies/AssemblyWithTypeFilter/TestClassIncludeAlso.cs
+++ b/TestAssemblies/AssemblyWithTypeFilter/TestClassIncludeAlso.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+
+namespace PropertyChangedTestWithDifferentNamespace
+{
+    public class TestClassIncludeAlso : INotifyPropertyChanged
+    {
+        public string Property1 { get; set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/Tests/TypeFilterTests.cs
+++ b/Tests/TypeFilterTests.cs
@@ -25,4 +25,14 @@ public class TypeFilterTests
         var instance = testResult.GetInstance("PropertyChangedTest.TestClassInclude");
         EventTester.TestProperty(instance, false);
     }
+
+    [Fact]
+    public void CheckIfMultipleFilterTypeIncludeCorrectTypes()
+    {
+        var instance1 = testResult.GetInstance("PropertyChangedTest.TestClassInclude");
+        var instance2 = testResult.GetInstance("PropertyChangedTestWithDifferentNamespace.TestClassIncludeAlso");
+
+        EventTester.TestProperty(instance1, false);
+        EventTester.TestProperty(instance2, false);
+    }
 }


### PR DESCRIPTION
Docs say

> To scope the rewriting only to specific classes, and not the whole Assembly, you can use the FilterType attribute. This changes the general behavior from from opt-out to opt-in. Example: [assembly: PropertyChanged.FilterType("My.Specific.OptIn.Namespace.")]. The string is interpreted as a Regex, and you can use **multiple** filters. A class will be weaved, if any filter matches.

This is not possible if AllowMultiple is not set to true for FilterTypeAttribute, which this pull request does.