### PR TITLE
Add GeneratedCodeAttribute and DebuggerNonUserCodeAttribute to the generated <>OnPropertyChanged method

### DIFF
--- a/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
+++ b/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
@@ -3,8 +3,8 @@ using Mono.Collections.Generic;
 
 public partial class ModuleWeaver
 {
-    static string AssemblyVersion = typeof(ModuleWeaver).Assembly.GetName().Version.ToString();
-    static string AssemblyName = typeof(ModuleWeaver).Assembly.GetName().Name;
+    static readonly string AssemblyVersion = typeof(ModuleWeaver).Assembly.GetName().Version.ToString();
+    static readonly string AssemblyName = typeof(ModuleWeaver).Assembly.GetName().Name;
 
     public void MarkAsGeneratedCode(Collection<CustomAttribute> customAttributes)
     {

--- a/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
+++ b/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
@@ -3,6 +3,9 @@ using Mono.Collections.Generic;
 
 public partial class ModuleWeaver
 {
+    static string AssemblyVersion = typeof(ModuleWeaver).Assembly.GetName().Version.ToString();
+    static string AssemblyName = typeof(ModuleWeaver).Assembly.GetName().Name;
+
     public void MarkAsGeneratedCode(Collection<CustomAttribute> customAttributes)
     {
         AddCustomAttributeArgument(customAttributes);
@@ -17,12 +20,9 @@ public partial class ModuleWeaver
 
     void AddCustomAttributeArgument(Collection<CustomAttribute> customAttributes)
     {
-        var version = typeof(ModuleWeaver).Assembly.GetName().Version.ToString();
-        var name = typeof(ModuleWeaver).Assembly.GetName().Name;
-
         var attribute = new CustomAttribute(GeneratedCodeAttributeConstructor);
-        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, name));
-        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, version));
+        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, AssemblyName));
+        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, AssemblyVersion));
         customAttributes.Add(attribute);
     }
 }

--- a/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
+++ b/PropertyChanged.Fody/CollectionCustomAttributeExtension.cs
@@ -1,0 +1,28 @@
+﻿using Mono.Cecil;
+using Mono.Collections.Generic;
+
+public partial class ModuleWeaver
+{
+    public void MarkAsGeneratedCode(Collection<CustomAttribute> customAttributes)
+    {
+        AddCustomAttributeArgument(customAttributes);
+        AddDebuggerNonUserCodeAttribute(customAttributes);
+    }
+
+    void AddDebuggerNonUserCodeAttribute(Collection<CustomAttribute> customAttributes)
+    {
+        var debuggerAttribute = new CustomAttribute(DebuggerNonUserCodeAttributeConstructor);
+        customAttributes.Add(debuggerAttribute);
+    }
+
+    void AddCustomAttributeArgument(Collection<CustomAttribute> customAttributes)
+    {
+        var version = typeof(ModuleWeaver).Assembly.GetName().Version.ToString();
+        var name = typeof(ModuleWeaver).Assembly.GetName().Name;
+
+        var attribute = new CustomAttribute(GeneratedCodeAttributeConstructor);
+        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, name));
+        attribute.ConstructorArguments.Add(new CustomAttributeArgument(TypeSystem.StringReference, version));
+        customAttributes.Add(attribute);
+    }
+}

--- a/PropertyChanged.Fody/EventArgsCache.cs
+++ b/PropertyChanged.Fody/EventArgsCache.cs
@@ -10,6 +10,7 @@ public class EventArgsCache
         this.moduleWeaver = moduleWeaver;
         var attributes = TypeAttributes.AutoClass | TypeAttributes.AutoLayout | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit | TypeAttributes.Class | TypeAttributes.NotPublic;
         cacheTypeDefinition = new TypeDefinition(null, "<>PropertyChangedEventArgs", attributes, moduleWeaver.TypeSystem.ObjectReference);
+        moduleWeaver.MarkAsGeneratedCode(cacheTypeDefinition.CustomAttributes);
     }
 
     public FieldReference GetEventArgsField(string propertyName)

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -105,6 +105,7 @@ public partial class ModuleWeaver
     MethodDefinition InjectFsharp(TypeDefinition targetType, FieldDefinition fsharpEvent)
     {
         var method = new MethodDefinition(injectedEventInvokerName, GetMethodAttributes(targetType), TypeSystem.VoidReference);
+        MarkAsGeneratedCode(method.CustomAttributes);
         method.Parameters.Add(new ParameterDefinition("propertyName", ParameterAttributes.None, TypeSystem.StringReference));
 
         var instructions = method.Body.Instructions;
@@ -124,6 +125,7 @@ public partial class ModuleWeaver
     MethodDefinition InjectNormal(TypeDefinition targetType, FieldReference propertyChangedField)
     {
         var method = new MethodDefinition(injectedEventInvokerName, GetMethodAttributes(targetType), TypeSystem.VoidReference);
+        MarkAsGeneratedCode(method.CustomAttributes);
         method.Parameters.Add(new ParameterDefinition("propertyName", ParameterAttributes.None, TypeSystem.StringReference));
 
         var handlerVariable = new VariableDefinition(PropChangedHandlerReference);
@@ -153,6 +155,7 @@ public partial class ModuleWeaver
     MethodDefinition InjectEventArgsMethod(TypeDefinition targetType, FieldReference propertyChangedField)
     {
         var method = new MethodDefinition(injectedEventInvokerName, GetMethodAttributes(targetType), TypeSystem.VoidReference);
+        MarkAsGeneratedCode(method.CustomAttributes);
         method.Parameters.Add(new ParameterDefinition("eventArgs", ParameterAttributes.None, PropertyChangedEventArgsReference));
 
         var handlerVariable = new VariableDefinition(PropChangedHandlerReference);

--- a/PropertyChanged.Fody/MsCoreReferenceFinder.cs
+++ b/PropertyChanged.Fody/MsCoreReferenceFinder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Rocks;
 
 public partial class ModuleWeaver
 {
@@ -21,6 +22,8 @@ public partial class ModuleWeaver
     public GenericInstanceMethod InterlockedCompareExchangeForPropChangedHandler;
     public Lazy<MethodReference> Trigger;
     public MethodReference StringEquals;
+    public MethodReference DebuggerNonUserCodeAttributeConstructor;
+    public MethodReference GeneratedCodeAttributeConstructor;
 
     public override IEnumerable<string> GetAssembliesForScanning()
     {
@@ -104,5 +107,13 @@ public partial class ModuleWeaver
 
             return null;
         });
+
+        var generatedCodeType = FindType("System.CodeDom.Compiler.GeneratedCodeAttribute");
+        var generatedCodeAttributeConstructor = generatedCodeType.GetConstructors().Single(c => c.Parameters.Count == 2 && c.Parameters.All(p => p.ParameterType.Name == "String"));
+        GeneratedCodeAttributeConstructor = ModuleDefinition.ImportReference(generatedCodeAttributeConstructor);
+
+        var debuggerNonUserCodeType = FindType("System.Diagnostics.DebuggerNonUserCodeAttribute");
+        var debuggerNonUserCodeConstructor = debuggerNonUserCodeType.GetConstructors().Single(c => !c.HasParameters);
+        DebuggerNonUserCodeAttributeConstructor = ModuleDefinition.ImportReference(debuggerNonUserCodeConstructor);
     }
 }


### PR DESCRIPTION
Where it is clear the below content has not read, the issue is likely to be closed with "please read the template". Please don't take offense at this. It is simply a time management decision. When someone raises an issue, without reading the template, then often too much time is spent going back and forth to obtain information that is outlined below.


#### You should already be a Patron

To be using Fody you should be a [Patron](https://opencollective.com/fody/order/3059). See [Licensing/Patron FAQ](https://github.com/Fody/Home/blob/master/pages/licensing-patron-faq.md). With that in mind, it is assumed anyone raising a PR is already a Patron. As such your GitHub Id may be verified against the [OpenCollective contributors](https://opencollective.com/fody#contributors). This process will depend on the PR quality, your circumstances, and the impact on the larger user base.


#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.


#### Description
Add GeneratedCodeAttribute and DebuggerNonUserCodeAttribute to the generated <>OnPropertyChanged method to avoid problems with static analysis tools and debuggers.

#### The solution
Just add the attributes when the method is generated.

#### Todos
 * [ ] Related issues: No issue created
 * [ ] Tests: Seems like these kind of things are not tested by other extensions too?
 * [ ] Documentation: No documentation needed as this is just about marking the code correctly with attributes