### PR TITLE
Add warnings for invalid On_PropertyName_Changed methods

### DIFF
--- a/PropertyChanged.Fody/AttributeCleaner.cs
+++ b/PropertyChanged.Fody/AttributeCleaner.cs
@@ -29,17 +29,20 @@ public partial class ModuleWeaver
     void ProcessType(TypeDefinition type)
     {
         RemoveAttributes(type, typeLevelAttributeNames);
+        
         foreach (var property in type.Properties)
         {
             RemoveAttributes(property, typeLevelAttributeNames);
         }
+        
         foreach (var field in type.Fields)
         {
             RemoveAttributes(field, typeLevelAttributeNames);
         }
-        foreach (var field in type.Methods)
+        
+        foreach (var method in type.Methods)
         {
-            RemoveAttributes(field, typeLevelAttributeNames);
+            RemoveAttributes(method, typeLevelAttributeNames);
         }
     }
 

--- a/PropertyChanged.Fody/Config/SuppressWarningsConfig.cs
+++ b/PropertyChanged.Fody/Config/SuppressWarningsConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool SuppressWarnings;
+
+    public void ResolveSuppressWarningsConfig()
+    {
+        var value = Config?.Attributes("SuppressWarnings")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            SuppressWarnings = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/EqualityCheckWeaver.cs
+++ b/PropertyChanged.Fody/EqualityCheckWeaver.cs
@@ -86,7 +86,7 @@ public class EqualityCheckWeaver
             }
             catch (Exception ex)
             {
-                typeEqualityFinder.LogWarning($"Ignoring Ceq of type {targetType.FullName} => {ex.Message}");
+                typeEqualityFinder.EmitWarning($"Ignoring Ceq of type {targetType.FullName} => {ex.Message}");
             }
 
             if (supportsCeq && (targetType.IsValueType || !typeEqualityFinder.CheckForEqualityUsingBaseEquals))

--- a/PropertyChanged.Fody/IsChangedMethodFinder.cs
+++ b/PropertyChanged.Fody/IsChangedMethodFinder.cs
@@ -83,7 +83,7 @@ public partial class ModuleWeaver
         {
             if (propertyDefinition.PropertyType.FullName != TypeSystem.BooleanDefinition.FullName)
             {
-                LogWarning($"Found '{propertyDefinition.GetName()}' but is was of type '{propertyDefinition.PropertyType.Name}' instead of '{TypeSystem.BooleanDefinition.Name}' so it will not be used.");
+                EmitWarning($"Found '{propertyDefinition.GetName()}' but is was of type '{propertyDefinition.PropertyType.Name}' instead of '{TypeSystem.BooleanDefinition.Name}' so it will not be used.");
                 return false;
             }
             if (propertyDefinition.SetMethod.IsStatic)

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -8,6 +8,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         ResolveCheckForEqualityConfig();
         ResolveCheckForEqualityUsingBaseEqualsConfig();
         ResolveUseStaticEqualsFromBaseConfig();
+        ResolveSuppressWarningsConfig();
         ResolveEventInvokerName();
         FindCoreReferences();
         FindInterceptor();

--- a/PropertyChanged.Fody/NotifyInterfaceFinder.cs
+++ b/PropertyChanged.Fody/NotifyInterfaceFinder.cs
@@ -27,7 +27,7 @@ public partial class ModuleWeaver
             }
             catch (Exception ex)
             {
-                LogWarning($"Ignoring type {fullName} in type hierarchy => {ex.Message}");
+                EmitWarning($"Ignoring type {fullName} in type hierarchy => {ex.Message}");
                 return false;
             }
         }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -53,6 +53,10 @@ public partial class ModuleWeaver
                     MethodReference = GetMethodReference(typeDefinitions, methodDefinition)
                 };
             }
+            else if (!EventInvokerNames.Contains(methodDefinition.Name))
+            {
+                EmitConditionalWarning(methodDefinition, $"Unsupported signature for a On_PropertyName_Changed method: {methodDefinition.Name} in {methodDefinition.DeclaringType.FullName}");
+            }
         }
     }
 

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -24,8 +24,9 @@ public partial class ModuleWeaver
         var methods = notifyNode.TypeDefinition.Methods;
 
         var onChangedMethods = methods.Where(x => !x.IsStatic &&
-                                  x.Name.StartsWith("On") &&
-                                  x.Name.EndsWith("Changed"));
+                                                  x.Name.StartsWith("On") &&
+                                                  x.Name.EndsWith("Changed") &&
+                                                  x.Name != "OnChanged");
 
         foreach (var methodDefinition in onChangedMethods)
         {
@@ -34,11 +35,14 @@ public partial class ModuleWeaver
                 var message = $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) that has a non void return value. Ensure the return type void.";
                 throw new WeavingException(message);
             }
+            
             var typeDefinitions = new Stack<TypeDefinition>();
             typeDefinitions.Push(notifyNode.TypeDefinition);
 
             if (IsNoArgOnChangedMethod(methodDefinition))
             {
+                ValidateOnChangedMethod(notifyNode, methodDefinition);
+                
                 yield return new OnChangedMethod
                 {
                     OnChangedType = OnChangedTypes.NoArg,
@@ -47,6 +51,8 @@ public partial class ModuleWeaver
             }
             else if (IsBeforeAfterOnChangedMethod(methodDefinition))
             {
+                ValidateOnChangedMethod(notifyNode, methodDefinition);
+                
                 yield return new OnChangedMethod
                 {
                     OnChangedType = OnChangedTypes.BeforeAfter,
@@ -72,5 +78,18 @@ public partial class ModuleWeaver
         return parameters.Count == 2
                && parameters[0].ParameterType.FullName == "System.Object"
                && parameters[1].ParameterType.FullName == "System.Object";
+    }
+
+    void ValidateOnChangedMethod(TypeNode notifyNode, MethodDefinition method)
+    {
+        if (method.IsVirtual && !method.IsNewSlot)
+            return;
+        
+        var propertyName = method.Name.Substring("On".Length, method.Name.Length - "On".Length - "Changed".Length);
+
+        if (notifyNode.PropertyDatas.All(i => i.PropertyDefinition.Name != propertyName))
+        {
+            EmitConditionalWarning(method, $"Type {method.DeclaringType.FullName} does not contain a {propertyName} property with an injected change notification, and therefore the {method.Name} method will not be called.");
+        }
     }
 }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -23,13 +23,18 @@ public partial class ModuleWeaver
     {
         var methods = notifyNode.TypeDefinition.Methods;
 
-        var onChangedMethods = methods.Where(x => !x.IsStatic &&
-                                                  x.Name.StartsWith("On") &&
+        var onChangedMethods = methods.Where(x => x.Name.StartsWith("On") &&
                                                   x.Name.EndsWith("Changed") &&
                                                   x.Name != "OnChanged");
 
         foreach (var methodDefinition in onChangedMethods)
         {
+            if (methodDefinition.IsStatic)
+            {
+                var message = $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) which is static.";
+                throw new WeavingException(message);
+            }
+            
             if (methodDefinition.ReturnType.FullName != "System.Void")
             {
                 var message = $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) that has a non void return value. Ensure the return type void.";

--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -92,7 +92,7 @@ public partial class ModuleWeaver
         }
         catch (Exception ex)
         {
-            LogWarning($"Ignoring static equality of type {typeReference.FullName} => {ex.Message}");
+            EmitWarning($"Ignoring static equality of type {typeReference.FullName} => {ex.Message}");
             return null;
         }
 

--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -13,7 +13,7 @@ public partial class ModuleWeaver
                 var warning = CheckForWarning(propertyData, node.EventInvoker.InvokerType);
                 if (warning != null)
                 {
-                    LogDebug($"\t{propertyData.PropertyDefinition.GetName()} {warning} Property will be ignored.");
+                    EmitConditionalWarning(propertyData.PropertyDefinition, $"{propertyData.PropertyDefinition.GetName()} {warning} Property will be ignored.");
                     node.PropertyDatas.Remove(propertyData);
                 }
             }

--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -53,9 +53,20 @@ public partial class ModuleWeaver
     {
         CheckForWarnings(NotifyNodes);
     }
-    
-    void EmitConditionalWarning(ICustomAttributeProvider member, string message)
+
+    public void EmitWarning(string message)
     {
+        if (SuppressWarnings)
+            return;
+        
+        LogWarning?.Invoke(message);
+    }
+    
+    public void EmitConditionalWarning(ICustomAttributeProvider member, string message)
+    {
+        if (SuppressWarnings)
+            return;
+        
         if (member.HasCustomAttributes && member.CustomAttributes.ContainsAttribute("PropertyChanged.SuppressPropertyChangedWarningsAttribute"))
             return;
         

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithAttributeAndEve
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmokeTest", "SmokeTest\SmokeTest.csproj", "{7C7CF462-F512-4E0C-9476-E241B54D8E40}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithStaticOnPropertyNameChanged", "TestAssemblies\AssemblyWithStaticOnPropertyNameChanged\AssemblyWithStaticOnPropertyNameChanged.csproj", "{99568358-1828-4FB8-9140-506ABE536057}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -222,6 +224,18 @@ Global
 		{7C7CF462-F512-4E0C-9476-E241B54D8E40}.Release|ARM.Build.0 = Release|Any CPU
 		{7C7CF462-F512-4E0C-9476-E241B54D8E40}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C7CF462-F512-4E0C-9476-E241B54D8E40}.Release|x86.Build.0 = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|ARM.Build.0 = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Debug|x86.Build.0 = Debug|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|ARM.ActiveCfg = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|ARM.Build.0 = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|x86.ActiveCfg = Release|Any CPU
+		{99568358-1828-4FB8-9140-506ABE536057}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -241,6 +255,7 @@ Global
 		{257B24FC-1F76-47A6-BCD3-06EC78BDF8A5} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{EED92D0E-0DC4-43F4-95A5-1F067807C206} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{B28F547A-87F9-4F65-96DC-7911DEAB07AA} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{99568358-1828-4FB8-9140-506ABE536057} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/PropertyChanged/SuppressPropertyChangedWarningsAttribute.cs
+++ b/PropertyChanged/SuppressPropertyChangedWarningsAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace PropertyChanged
+{
+    /// <summary>
+    /// Suppresses warnings emitted by PropertyChanged.Fody
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class SuppressPropertyChangedWarningsAttribute : Attribute
+    {
+    }
+}

--- a/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
@@ -7,7 +7,10 @@ public class ClassWithInvalidOnChanged : INotifyPropertyChanged
     public string PropertyWithInvalidOnChangedMethodSuppressed { get; set; }
     public string PropertyWithValidOnChangedMethod { get; set; }
     
-    public void OnPropertyWithInvalidOnChangedMethodChanged (int foo)
+    [DoNotNotify]
+    public string IgnoredProperty { get; set; }
+
+    public void OnPropertyWithInvalidOnChangedMethodChanged(int foo)
     {
     }
 
@@ -15,8 +18,21 @@ public class ClassWithInvalidOnChanged : INotifyPropertyChanged
     public void OnPropertyWithInvalidOnChangedMethodSuppressedChanged(int foo)
     {
     }
+
+    public void OnPropertyWithValidOnChangedMethodChanged()
+    {
+    }
     
-    public void OnPropertyWithValidOnChangedMethodChanged ()
+    public void OnNonExistingPropertyChanged()
+    {
+    }
+
+    [SuppressPropertyChangedWarnings]
+    public void OnNonExistingPropertySuppressedChanged()
+    {
+    }
+    
+    public void OnIgnoredPropertyChanged()
     {
     }
 

--- a/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithInvalidOnChanged : INotifyPropertyChanged
+{
+    public string PropertyWithInvalidOnChangedMethod { get; set; }
+    public string PropertyWithInvalidOnChangedMethodSuppressed { get; set; }
+    public string PropertyWithValidOnChangedMethod { get; set; }
+    
+    public void OnPropertyWithInvalidOnChangedMethodChanged (int foo)
+    {
+    }
+
+    [SuppressPropertyChangedWarnings]
+    public void OnPropertyWithInvalidOnChangedMethodSuppressedChanged(int foo)
+    {
+    }
+    
+    public void OnPropertyWithValidOnChangedMethodChanged ()
+    {
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyWithStaticOnPropertyNameChanged/AssemblyWithStaticOnPropertyNameChanged.csproj
+++ b/TestAssemblies/AssemblyWithStaticOnPropertyNameChanged/AssemblyWithStaticOnPropertyNameChanged.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithStaticOnPropertyNameChanged/ClassWithNonVoidOnPropertyChanged.cs
+++ b/TestAssemblies/AssemblyWithStaticOnPropertyNameChanged/ClassWithNonVoidOnPropertyChanged.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+public class ClassWithStaticOnPropertyChanged : INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public static void OnProperty1Changed()
+    {
+    }
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -176,6 +176,16 @@ public class AssemblyToProcessTests :
         Assert.NotEqual(new Tuple<string, int>("b", 2), instance.Property2);
     }
 
+    [Fact]
+    public void InvalidOnPropertyNameChangedMethodSignatureEmitsWarning()
+    {
+        const string className = nameof(ClassWithInvalidOnChanged);
+
+        Assert.Contains(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.PropertyWithInvalidOnChangedMethod)));
+        Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.PropertyWithInvalidOnChangedMethodSuppressed)));
+        Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.PropertyWithValidOnChangedMethod)));
+    }
+
     public AssemblyToProcessTests(ITestOutputHelper output) :
         base(output)
     {

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -185,6 +185,17 @@ public class AssemblyToProcessTests :
         Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.PropertyWithInvalidOnChangedMethodSuppressed)));
         Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.PropertyWithValidOnChangedMethod)));
     }
+    
+    [Fact]
+    public void OnPropertyNameChangedMethodWithoutMatchingPropertyEmitsWarning()
+    {
+        const string className = nameof(ClassWithInvalidOnChanged);
+
+        Assert.Contains(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.OnNonExistingPropertyChanged)));
+        Assert.Contains(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.OnIgnoredPropertyChanged)));
+        Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(className) && w.Text.Contains(nameof(ClassWithInvalidOnChanged.OnNonExistingPropertySuppressedChanged)));
+        Assert.DoesNotContain(testResult.Warnings, w => w.Text.Contains(nameof(ClassWithOnChangedConcrete)) && w.Text.Contains(nameof(ClassWithOnChangedConcrete.OnProperty1Changed)));
+    }
 
     public AssemblyToProcessTests(ITestOutputHelper output) :
         base(output)

--- a/Tests/InjectOnPropertyNameChangedTests.cs
+++ b/Tests/InjectOnPropertyNameChangedTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 public class InjectOnPropertyNameChangedTests
 {
     [Fact]
-    public void ModuleWeaver_WhenInjectOnPropertyNameChangedIsTrue_ThrowsWeavingException()
+    public void ModuleWeaver_WhenInjectOnPropertyNameChangedIsTrue_ThrowsWeavingExceptionForNonVoidMethods()
     {
         var moduleWeaver = new ModuleWeaver { InjectOnPropertyNameChanged = true };
 
@@ -17,10 +17,24 @@ public class InjectOnPropertyNameChangedTests
     }
 
     [Fact]
+    public void ModuleWeaver_WhenInjectOnPropertyNameChangedIsTrue_ThrowsWeavingExceptionForStaticMethods()
+    {
+        var moduleWeaver = new ModuleWeaver { InjectOnPropertyNameChanged = true };
+
+        var weavingException = Assert.Throws<WeavingException>(() =>
+        {
+            moduleWeaver.ExecuteTestRun("AssemblyWithStaticOnPropertyNameChanged.dll");
+        });
+
+        Assert.Equal("The type ClassWithStaticOnPropertyChanged has a On_PropertyName_Changed method (OnProperty1Changed) which is static.", weavingException.Message);
+    }
+
+    [Fact]
     public void ModuleWeaver_WhenInjectOnPropertyNameChangedIsFalse_DoesNotThrowWeavingException()
     {
         var moduleWeaver = new ModuleWeaver { InjectOnPropertyNameChanged = false };
 
         moduleWeaver.ExecuteTestRun("AssemblyWithNonVoidOnPropertyNameChanged.dll");
+        moduleWeaver.ExecuteTestRun("AssemblyWithStaticOnPropertyNameChanged.dll");
     }
 }

--- a/Tests/SuppressWarningsConfigTests.cs
+++ b/Tests/SuppressWarningsConfigTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+public class SuppressWarningsConfigTests :
+    XunitApprovalBase
+{
+    [Fact]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressWarnings='false'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressWarningsConfig();
+        Assert.False(moduleWeaver.SuppressWarnings);
+    }
+
+    [Fact]
+    public void False0()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressWarnings='0'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressWarningsConfig();
+        Assert.False(moduleWeaver.SuppressWarnings);
+    }
+
+    [Fact]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressWarnings='True'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressWarningsConfig();
+        Assert.True(moduleWeaver.SuppressWarnings);
+    }
+
+    [Fact]
+    public void True1()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressWarnings='1'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressWarningsConfig();
+        Assert.True(moduleWeaver.SuppressWarnings);
+    }
+
+    [Fact]
+    public void Default()
+    {
+        var moduleWeaver = new ModuleWeaver();
+        moduleWeaver.ResolveSuppressWarningsConfig();
+        Assert.False(moduleWeaver.SuppressWarnings);
+    }
+
+    public SuppressWarningsConfigTests(ITestOutputHelper output) :
+        base(output)
+    {
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInterceptor\AssemblyWithInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithNonVoidOnPropertyNameChanged\AssemblyWithNonVoidOnPropertyNameChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithStackOverflow\AssemblyWithStackOverflow.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithStaticOnPropertyNameChanged\AssemblyWithStaticOnPropertyNameChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithTypeFilter\AssemblyWithTypeFilter.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a POC for #447. It's completely up for debate.

This PR adds warnings for invalid usages of `On_PropertyName_Changed` methods:
 - A method with an unexpected signature is found
 - No matching property is found, or the matching property does not get processed

It additionally adds an `[SuppressPropertyChangedWarnings]` attribute to let the user suppress these warnings, and a `SuppressWarnings` config attribute to suppress all warnings (in case you have a codebase where this change would trigger false positives for some reason).

Some other points for consideration:
 - Currently a non-void `On_PropertyName_Changed` method will cause an error. Should that be replaced with a warning (and ignoring the method)?
 - Currently static `On_PropertyName_Changed` methods are simply ignored. Should they cause warnings?
 - The `CheckForWarnings` method emits its warnings at the Debug log level. Shouldn't they be turned into real warnings?
 - Are there other cases where (suppressible) warnings could prove useful?
