### PR TITLE
explicitly throw exception if PropertyChange event is abstract

### DIFF
--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -60,7 +60,13 @@ public partial class ModuleWeaver
             throw new WeavingException("Found more than one PropertyChanged event");
         }
 
-        var fieldReferences = addMethods.Single().Body.Instructions
+        var method = addMethods[0];
+        if (method.IsAbstract)
+        {
+            throw new WeavingException($"{targetType.FullName}.PropertyChanged event is abstract");
+        }
+
+        var fieldReferences = method.Body.Instructions
             .Where(i => i.OpCode == OpCodes.Ldfld || i.OpCode == OpCodes.Ldflda || i.OpCode == OpCodes.Stfld)
             .Select(i => i.Operand)
             .OfType<FieldReference>()


### PR DESCRIPTION
#### Description

(copied from #473)

**TL;DR**: Having PropertyChanged event declared as abstract causes NRE in `ModuleWeaver.GetEventHandlerField()` due to `addMethods.Single().Body.Instructions` being null.
___

**Long story**: here's the minimal setup to reproduce the bug:

``` C#
    abstract class BaseClass : INotifyPropertyChanged
    {
        public abstract event PropertyChangedEventHandler PropertyChanged;
    }
```

I understand that such setup is very uncommon, and I've even run into it by mistake. But then I've spent a few hours debugging the issue, because the actual crash doesn't reveal much of useful info:

```
1>MSBUILD : error : Fody: An unhandled exception occurred:
1>MSBUILD : error : Exception:
1>MSBUILD : error : Failed to execute weaver C:\Users\user\source\repos\FodyTest\packages\PropertyChanged.Fody.3.1.3\build\..\weaver\PropertyChanged.Fody.dll
1>MSBUILD : error : Type:
1>MSBUILD : error : System.Exception
1>MSBUILD : error : StackTrace:
1>MSBUILD : error :    at InnerWeaver.ExecuteWeavers() in C:\projects\fody\FodyIsolated\InnerWeaver.cs:line 210
1>MSBUILD : error :    at InnerWeaver.Execute() in C:\projects\fody\FodyIsolated\InnerWeaver.cs:line 111
1>MSBUILD : error : Source:
1>MSBUILD : error : FodyIsolated
1>MSBUILD : error : TargetSite:
1>MSBUILD : error : Void ExecuteWeavers()
1>MSBUILD : error : Object reference not set to an instance of an object.
1>MSBUILD : error : Type:
1>MSBUILD : error : System.NullReferenceException
1>MSBUILD : error : StackTrace:
1>MSBUILD : error :    at ModuleWeaver.GetEventHandlerField(TypeDefinition targetType)
1>MSBUILD : error :    at ModuleWeaver.InjectMethod(TypeDefinition targetType, InvokerTypes& invokerType)
1>MSBUILD : error :    at ModuleWeaver.AddOnPropertyChangedMethod(TypeDefinition targetType)
1>MSBUILD : error :    at ModuleWeaver.FindMethodsForNodes()
1>MSBUILD : error :    at ModuleWeaver.Execute()
1>MSBUILD : error :    at InnerWeaver.ExecuteWeavers() in C:\projects\fody\FodyIsolated\InnerWeaver.cs:line 198
1>MSBUILD : error : Source:
1>MSBUILD : error : PropertyChanged.Fody
1>MSBUILD : error : TargetSite:
1>MSBUILD : error : Mono.Cecil.FieldDefinition GetEventHandlerField(Mono.Cecil.TypeDefinition)
1>MSBUILD : error : 
```
You see, no mention of problematic type. So I think at least proper exception from `ModuleWeaver.GetEventHandlerField()` like the one below could be useful:

``` C#
    if (addMethods.Single().IsAbstract)
        throw new ArgumentException($"{targetType}.PropertyChanged is abstract");
```

#### The solution

That's a very uncommon and doubtful case, so no reason to put a work on real support. But generating proper exception will be useful.

#### Todos

fixes #473 
is ever a test needed?
no documentation changes required