### PR TITLE
Fix references to event invokers when a generic class is in the inheritance chain

### DIFF
--- a/PropertyChanged.Fody/MethodFinder.cs
+++ b/PropertyChanged.Fody/MethodFinder.cs
@@ -10,7 +10,7 @@ public partial class ModuleWeaver
         var childEventInvoker = FindEventInvokerMethod(node.TypeDefinition);
         if (childEventInvoker == null)
         {
-            if (node.TypeDefinition.BaseType.IsGenericInstance)
+            if (node.TypeDefinition.BaseType.IsGenericInstance && eventInvoker.MethodReference.DeclaringType.GetElementType() == node.TypeDefinition.BaseType.GetElementType())
             {
                 var methodReference = MakeGeneric(node.TypeDefinition.BaseType, eventInvoker.MethodReference);
                 eventInvoker = new EventInvokerMethod

--- a/PropertyChanged.Fody/MethodGenerifier.cs
+++ b/PropertyChanged.Fody/MethodGenerifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Mono.Cecil;
 
 public partial class ModuleWeaver
@@ -6,12 +7,12 @@ public partial class ModuleWeaver
     public MethodReference GetMethodReference(Stack<TypeDefinition> typeDefinitions, MethodDefinition methodDefinition)
     {
         var methodReference = ModuleDefinition.ImportReference(methodDefinition).GetGeneric();
-        typeDefinitions.Pop();
-        while (typeDefinitions.Count > 0)
+
+        if (methodReference.DeclaringType.IsGenericInstance && typeDefinitions.Count > 1)
         {
-            var definition = typeDefinitions.Pop();
-            methodReference = MakeGeneric(definition.BaseType, methodReference);
+            methodReference = MakeGeneric(typeDefinitions.Last().BaseType, methodReference);
         }
+
         return methodReference;
     }
 

--- a/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddle.cs
+++ b/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddle.cs
@@ -1,0 +1,3 @@
+public class ClassWithGenericMiddle<T> : ClassWithGenericMiddleBase
+{
+}

--- a/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddleBase.cs
+++ b/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddleBase.cs
@@ -1,0 +1,6 @@
+using System.ComponentModel;
+
+public class ClassWithGenericMiddleBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddleChild.cs
+++ b/TestAssemblies/AssemblyToProcess/GenericMiddle/ClassWithGenericMiddleChild.cs
@@ -1,0 +1,4 @@
+public class ClassWithGenericMiddleChild : ClassWithGenericMiddle<string>
+{
+    public int Property { get; set; }
+}

--- a/TestAssemblies/AssemblyWithBase/GenericMiddle/BaseClassWithGenericMiddle.cs
+++ b/TestAssemblies/AssemblyWithBase/GenericMiddle/BaseClassWithGenericMiddle.cs
@@ -1,0 +1,3 @@
+public class BaseClassWithGenericMiddle<T> : BaseClassWithGenericMiddleBase
+{
+}

--- a/TestAssemblies/AssemblyWithBase/GenericMiddle/BaseClassWithGenericMiddleBase.cs
+++ b/TestAssemblies/AssemblyWithBase/GenericMiddle/BaseClassWithGenericMiddleBase.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+
+public class BaseClassWithGenericMiddleBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+    
+    public virtual void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TestAssemblies/AssemblyWithBaseInDifferentModule/GenericMiddle/ClassWithGenericMiddleChildInDifferentModule.cs
+++ b/TestAssemblies/AssemblyWithBaseInDifferentModule/GenericMiddle/ClassWithGenericMiddleChildInDifferentModule.cs
@@ -1,0 +1,4 @@
+public class ClassWithGenericMiddleChildInDifferentModule : BaseClassWithGenericMiddle<string>
+{
+    public int Property { get; set; }
+}


### PR DESCRIPTION
Fixes #477

This is a WIP as I found a similar problem happens when the base class is in a different assembly (a totally different code path is used in that case). I didn't fix it yet as I'm not really sure about the correct way to do this.
