### PR TITLE
Call explicit interface methods correctly

### DIFF
--- a/PropertyChanged.Fody/MethodFinder.cs
+++ b/PropertyChanged.Fody/MethodFinder.cs
@@ -124,10 +124,22 @@ public partial class ModuleWeaver
             return methodDefinition;
         }
 
-        return type.Methods
+        methodDefinition = type.Methods
             .Where(x => EventInvokerNames.Contains(x.Name))
             .OrderByDescending(GetInvokerPriority)
             .FirstOrDefault(IsEventInvokerMethod);
+
+        if (methodDefinition != null &&
+            methodDefinition.IsPrivate &&
+            methodDefinition.IsFinal &&
+            methodDefinition.IsVirtual &&
+            methodDefinition.Overrides.Count == 1)
+        {
+            // Explicitly implemented interfaces should call the interface method instead
+            return methodDefinition.Overrides[0].Resolve();
+        }
+
+        return methodDefinition;
     }
 
     MethodReference FindExplicitImplementation(TypeDefinition type)


### PR DESCRIPTION
This fixes #508

The problem is I could not replicate the issue without having the test assembly use an external reference to the ReactiveUI library.