### PR TITLE
Suppress on property name changed config

### DIFF
--- a/PropertyChanged.Fody/Config/SuppressOnPropertyNameChangedWarningConfig.cs
+++ b/PropertyChanged.Fody/Config/SuppressOnPropertyNameChangedWarningConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool SuppressOnPropertyNameChangedWarning;
+
+    public void ResolveSuppressOnPropertyNameChangedWarningConfig()
+    {
+        var value = Config?.Attributes("SuppressOnPropertyNameChangedWarning")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            SuppressOnPropertyNameChangedWarning = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -9,6 +9,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         ResolveCheckForEqualityUsingBaseEqualsConfig();
         ResolveUseStaticEqualsFromBaseConfig();
         ResolveSuppressWarningsConfig();
+        ResolveSuppressOnPropertyNameChangedWarningConfig();
         ResolveEventInvokerName();
         FindCoreReferences();
         FindInterceptor();

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -98,7 +98,8 @@ public partial class ModuleWeaver
 
             if (foundMethod != null)
             {
-                throw new WeavingException($"The type {notifyNode.TypeDefinition.FullName} has multiple valid overloads of a On_PropertyName_Changed method named {methodName}).");}
+                throw new WeavingException($"The type {notifyNode.TypeDefinition.FullName} has multiple valid overloads of a On_PropertyName_Changed method named {methodName}).");
+            }
 
             foundMethod = method;
         }
@@ -115,13 +116,19 @@ public partial class ModuleWeaver
     {
         if (methodDefinition.IsStatic)
         {
-            EmitConditionalWarning(methodDefinition, $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) which is static.");
+            if (!SuppressOnPropertyNameChangedWarning)
+            {
+                EmitConditionalWarning(methodDefinition, $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) which is static.");
+            }
             return null;
         }
 
         if (methodDefinition.ReturnType.FullName != "System.Void")
         {
-            EmitConditionalWarning(methodDefinition, $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) that has a non void return value. Ensure the return type void.");
+            if (!SuppressOnPropertyNameChangedWarning)
+            {
+                EmitConditionalWarning(methodDefinition, $"The type {notifyNode.TypeDefinition.FullName} has a On_PropertyName_Changed method ({methodDefinition.Name}) that has a non void return value. Ensure the return type void.");
+            }
             return null;
         }
 
@@ -151,7 +158,7 @@ public partial class ModuleWeaver
             };
         }
 
-        if (!EventInvokerNames.Contains(methodDefinition.Name))
+        if (!EventInvokerNames.Contains(methodDefinition.Name) && !SuppressOnPropertyNameChangedWarning)
         {
             EmitConditionalWarning(methodDefinition, $"Unsupported signature for a On_PropertyName_Changed method: {methodDefinition.Name} in {methodDefinition.DeclaringType.FullName}");
         }
@@ -190,6 +197,9 @@ public partial class ModuleWeaver
         {
             return;
         }
-        EmitConditionalWarning(method, $"Type {method.DeclaringType.FullName} does not contain a {propertyName} property with an injected change notification, and therefore the {method.Name} method will not be called.");
+        if (!SuppressOnPropertyNameChangedWarning)
+        {
+            EmitConditionalWarning(method, $"Type {method.DeclaringType.FullName} does not contain a {propertyName} property with an injected change notification, and therefore the {method.Name} method will not be called.");
+        }
     }
 }

--- a/PropertyChanged.Fody/PropertyChanged.Fody.xcf
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.xcf
@@ -25,4 +25,9 @@
       <xs:documentation>Used to control if equality checks should use the static Equals method resolved from the base class.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="SuppressWarnings" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Used to turn off build warnings from this weaver.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
 </xs:complexType>

--- a/PropertyChanged.Fody/PropertyChanged.Fody.xcf
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.xcf
@@ -30,4 +30,9 @@
       <xs:documentation>Used to turn off build warnings from this weaver.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="SuppressOnPropertyNameChangedWarning" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Used to turn off build warnings about mismatched On_PropertyName_Changed methods.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
 </xs:complexType>

--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -67,7 +67,7 @@ public partial class ModuleWeaver
 
     public void EmitConditionalWarning(ICustomAttributeProvider member, string message)
     {
-        if (SuppressWarnings || SuppressOnPropertyNameChangedWarning)
+        if (SuppressWarnings)
         {
             return;
         }

--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -67,7 +67,7 @@ public partial class ModuleWeaver
 
     public void EmitConditionalWarning(ICustomAttributeProvider member, string message)
     {
-        if (SuppressWarnings)
+        if (SuppressWarnings || SuppressOnPropertyNameChangedWarning)
         {
             return;
         }

--- a/SmokeTest/FodyWeavers.xsd
+++ b/SmokeTest/FodyWeavers.xsd
@@ -36,6 +36,11 @@
                 <xs:documentation>Used to turn off build warnings from this weaver.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="SuppressOnPropertyNameChangedWarning" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to turn off build warnings about mismatched On_PropertyName_Changed methods.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/SmokeTest/FodyWeavers.xsd
+++ b/SmokeTest/FodyWeavers.xsd
@@ -31,6 +31,11 @@
                 <xs:documentation>Used to control if equality checks should use the static Equals method resolved from the base class.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="SuppressWarnings" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to turn off build warnings from this weaver.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/Tests/SuppressOnPropertyNameChangedWarningConfigTests.cs
+++ b/Tests/SuppressOnPropertyNameChangedWarningConfigTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Xml.Linq;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class SuppressOnPropertyNameChangedWarningConfigTests :
+    VerifyBase
+{
+    [Fact]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressOnPropertyNameChangedWarning='false'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressOnPropertyNameChangedWarningConfig();
+        Assert.False(moduleWeaver.SuppressOnPropertyNameChangedWarning);
+    }
+
+    [Fact]
+    public void False0()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressOnPropertyNameChangedWarning='0'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressOnPropertyNameChangedWarningConfig();
+        Assert.False(moduleWeaver.SuppressOnPropertyNameChangedWarning);
+    }
+
+    [Fact]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressOnPropertyNameChangedWarning='True'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressOnPropertyNameChangedWarningConfig();
+        Assert.True(moduleWeaver.SuppressOnPropertyNameChangedWarning);
+    }
+
+    [Fact]
+    public void True1()
+    {
+        var xElement = XElement.Parse("<PropertyChanged SuppressOnPropertyNameChangedWarning='1'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ResolveSuppressOnPropertyNameChangedWarningConfig();
+        Assert.True(moduleWeaver.SuppressOnPropertyNameChangedWarning);
+    }
+
+    [Fact]
+    public void Default()
+    {
+        var moduleWeaver = new ModuleWeaver();
+        moduleWeaver.ResolveSuppressOnPropertyNameChangedWarningConfig();
+        Assert.False(moduleWeaver.SuppressOnPropertyNameChangedWarning);
+    }
+
+    public SuppressOnPropertyNameChangedWarningConfigTests(ITestOutputHelper output) :
+        base(output)
+    {
+    }
+}


### PR DESCRIPTION
#### Description

This PR fixes the missing config schema for `SuppressWarnings`
This PR adds a new config `SuppressOnPropertyNameChanged`

Fixes #539

#### Todos

 * [ ] The [options](https://github.com/Fody/PropertyChanged/wiki/Options) page needs to be updated
