### PR TITLE
Ignore indexer dependencies

### DIFF
--- a/PropertyChanged.Fody/DependsOnDataAttributeReader.cs
+++ b/PropertyChanged.Fody/DependsOnDataAttributeReader.cs
@@ -23,6 +23,11 @@ public partial class ModuleWeaver
 
     public void ReadDependsOnData(PropertyDefinition property, TypeNode node)
     {
+        if (property.HasParameters)
+        {
+            return;
+        }
+
         var dependsOnAttribute = property.CustomAttributes.GetAttribute("PropertyChanged.DependsOnAttribute");
         if (dependsOnAttribute == null)
         {

--- a/PropertyChanged.Fody/IlGeneratedByDependencyReader.cs
+++ b/PropertyChanged.Fody/IlGeneratedByDependencyReader.cs
@@ -57,6 +57,12 @@ public class IlGeneratedByDependencyReader
 
     void ProcessGet(PropertyDefinition property)
     {
+        //Exclude indexers
+        if (property.HasParameters)
+        {
+            return;
+        }
+
         var getMethod = property.GetMethod;
 
         //Exclude when no get

--- a/TestAssemblies/AssemblyToProcess/ClassWithIndexerDependsOnAndBeforeAfter.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithIndexerDependsOnAndBeforeAfter.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithIndexerDependsOnAndBeforeAfter :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    [DependsOn(nameof(Property1))]
+    public string this[int i]
+    {
+        get => null;
+    }
+
+    public void OnPropertyChanged(string propertyName, object before, object after)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/ClassWithIndexerReferencingPropertyAndBeforeAfter.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithIndexerReferencingPropertyAndBeforeAfter.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+
+public class ClassWithIndexerReferencingPropertyAndBeforeAfter :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public string this[int i]
+    {
+        get => Property1;
+    }
+
+    public void OnPropertyChanged(string propertyName, object before, object after)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -108,6 +108,20 @@ public class AssemblyToProcessTests :
     }
 
     [Fact]
+    public void ClassWithIndexerReferencingPropertyAndBeforeAfter()
+    {
+        var instance = testResult.GetInstance(nameof(ClassWithIndexerReferencingPropertyAndBeforeAfter));
+        EventTester.TestProperty(instance, false);
+    }
+
+    [Fact]
+    public void ClassWithIndexerDependsOnAndBeforeAfter()
+    {
+        var instance = testResult.GetInstance(nameof(ClassWithIndexerDependsOnAndBeforeAfter));
+        EventTester.TestProperty(instance, false);
+    }
+
+    [Fact]
     public void UseSingleEventInstance()
     {
         var instance = testResult.GetInstance("ClassWithNotifyPropertyChangedAttribute");


### PR DESCRIPTION
Fixes #544 by ignoring indexers in dependency resolution. Also Ignores `[DependsOn]` on indexers.
