### PR TITLE
Limit field mapping to fields of the same type as the property

### DIFF
--- a/PropertyChanged.Fody/MappingFinder.cs
+++ b/PropertyChanged.Fody/MappingFinder.cs
@@ -31,7 +31,7 @@ public partial class ModuleWeaver
     static FieldDefinition TryGetField(TypeDefinition typeDefinition, PropertyDefinition property)
     {
         var propertyName = property.Name;
-        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition).ToList();
+        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition && x.FieldType == property.PropertyType).ToList();
         foreach (var field in fieldsWithSameType)
         {
             //AutoProp

--- a/TestAssemblies/AssemblyToProcess/ClassWithNullableBackingField.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithNullableBackingField.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+
+public class ClassWithNullableBackingField : INotifyPropertyChanged
+{
+    bool? _isFlag;
+
+    public bool IsFlag
+    {
+        get => _isFlag ?? (_isFlag = GetFlag()).Value;
+        set => _isFlag = value;
+    }
+
+    bool GetFlag() => false;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -371,6 +371,26 @@ public class AssemblyToProcessTests :
         }
     }
 
+    [Fact]
+    public void ClassWithNullableBackingField()
+    {
+        var instance = testResult.GetInstance("ClassWithNullableBackingField");
+        var isFlagEventCalled = false;
+        ((INotifyPropertyChanged)instance).PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == "IsFlag")
+            {
+                isFlagEventCalled = true;
+            }
+        };
+        instance.IsFlag = true;
+        Assert.True(isFlagEventCalled);
+
+        isFlagEventCalled = false;
+        instance.IsFlag = true;
+        Assert.False(isFlagEventCalled);
+    }
+
     public AssemblyToProcessTests(ITestOutputHelper output) :
         base(output)
     {


### PR DESCRIPTION
This is the same change as in https://github.com/Fody/PropertyChanging/pull/160

A similar issue to https://github.com/Fody/PropertyChanging/pull/156 exists here, but instead of producing an invalid program, the equality check was skipped.
