### PR TITLE
Add an option to disable automatic dependent property changed. #282

### DIFF
--- a/PropertyChanged.Fody/Config/EnableIsChangedPropertyConfig.cs
+++ b/PropertyChanged.Fody/Config/EnableIsChangedPropertyConfig.cs
@@ -12,7 +12,7 @@ public partial class ModuleWeaver
             .SingleOrDefault();
         if (value != null)
         {
-            TriggerDependentProperties = XmlConvert.ToBoolean(value.ToLowerInvariant());
+            EnableIsChangedProperty = XmlConvert.ToBoolean(value.ToLowerInvariant());
         }
     }
 }

--- a/PropertyChanged.Fody/Config/EnableIsChangedPropertyConfig.cs
+++ b/PropertyChanged.Fody/Config/EnableIsChangedPropertyConfig.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool EnableIsChangedProperty = true;
+
+    public void ResolveEnableIsChangedPropertyConfig()
+    {
+        var value = Config?.Attributes("EnableIsChangedProperty")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            TriggerDependentProperties = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/Config/TriggerDependentPropertiesConfig.cs
+++ b/PropertyChanged.Fody/Config/TriggerDependentPropertiesConfig.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool TriggerDependentProperties = true;
+
+    public void ResolveTriggerDependentPropertiesConfig()
+    {
+        var value = Config?.Attributes("TriggerDependentProperties")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            TriggerDependentProperties = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/IlGeneratedByDependencyProcessor.cs
+++ b/PropertyChanged.Fody/IlGeneratedByDependencyProcessor.cs
@@ -9,6 +9,11 @@ public partial class ModuleWeaver
 
     void DetectIlGeneratedByDependency(List<TypeNode> notifyNodes)
     {
+        if(!TriggerDependentProperties)
+        {
+            return;
+        }
+
         foreach (var node in notifyNodes)
         {
             var ilGeneratedByDependencyReader = new IlGeneratedByDependencyReader(node);

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -5,6 +5,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
     public override void Execute()
     {
         ResolveOnPropertyNameChangedConfig();
+        ResolveEnableIsChangedPropertyConfig();
         ResolveTriggerDependentPropertiesConfig();
         ResolveCheckForEqualityConfig();
         ResolveCheckForEqualityUsingBaseEqualsConfig();

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -5,6 +5,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
     public override void Execute()
     {
         ResolveOnPropertyNameChangedConfig();
+        ResolveTriggerDependentPropertiesConfig();
         ResolveCheckForEqualityConfig();
         ResolveCheckForEqualityUsingBaseEqualsConfig();
         ResolveUseStaticEqualsFromBaseConfig();

--- a/PropertyChanged.Fody/PropertyChanged.Fody.xcf
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.xcf
@@ -10,6 +10,11 @@
       <xs:documentation>Used to control if the Dependent properties feature is enabled.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="EnableIsChangedProperty" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Used to control if the IsChanged property feature is enabled.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:attribute name="EventInvokerNames" type="xs:string" >
     <xs:annotation>
       <xs:documentation>Used to change the name of the method that fires the notify event. This is a string that accepts multiple values in a comma separated form.</xs:documentation>

--- a/PropertyChanged.Fody/PropertyChanged.Fody.xcf
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.xcf
@@ -5,6 +5,11 @@
       <xs:documentation>Used to control if the On_PropertyName_Changed feature is enabled.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="TriggerDependentProperties" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Used to control if the Dependent properties feature is enabled.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:attribute name="EventInvokerNames" type="xs:string" >
     <xs:annotation>
       <xs:documentation>Used to change the name of the method that fires the notify event. This is a string that accepts multiple values in a comma separated form.</xs:documentation>

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -124,7 +124,7 @@ public class PropertyWeaver
 
     int AddIsChangedSetterCall(int index)
     {
-        if (typeNode.IsChangedInvoker == null ||
+        if (!moduleWeaver.EnableIsChangedProperty || typeNode.IsChangedInvoker == null ||
             propertyData.PropertyDefinition.CustomAttributes.ContainsAttribute("PropertyChanged.DoNotSetChangedAttribute") ||
             propertyData.PropertyDefinition.Name == "IsChanged")
         {

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -54,6 +54,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithStaticOnPropert
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithDisabledInjectOnPropertyNameChanged", "TestAssemblies\AssemblyWithDisabledInjectOnPropertyNameChanged\AssemblyWithDisabledInjectOnPropertyNameChanged.csproj", "{CE399B3E-5BC3-40DA-95C5-F83FC9581636}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithDisabledTriggerDependentProperties", "TestAssemblies\AssemblyWithDisabledTriggerDependentProperties\AssemblyWithDisabledTriggerDependentProperties.csproj", "{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -252,6 +254,18 @@ Global
 		{CE399B3E-5BC3-40DA-95C5-F83FC9581636}.Release|ARM.Build.0 = Release|Any CPU
 		{CE399B3E-5BC3-40DA-95C5-F83FC9581636}.Release|x86.ActiveCfg = Release|Any CPU
 		{CE399B3E-5BC3-40DA-95C5-F83FC9581636}.Release|x86.Build.0 = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Debug|x86.Build.0 = Debug|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|ARM.Build.0 = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|x86.ActiveCfg = Release|Any CPU
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -273,6 +287,7 @@ Global
 		{B28F547A-87F9-4F65-96DC-7911DEAB07AA} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{99568358-1828-4FB8-9140-506ABE536057} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{CE399B3E-5BC3-40DA-95C5-F83FC9581636} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -56,6 +56,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithDisabledInjectO
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithDisabledTriggerDependentProperties", "TestAssemblies\AssemblyWithDisabledTriggerDependentProperties\AssemblyWithDisabledTriggerDependentProperties.csproj", "{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithDisabledIsChangedProperty", "TestAssemblies\AssemblyWithDisabledIsChangedProperty\AssemblyWithDisabledIsChangedProperty.csproj", "{89CC72A8-43A9-4593-9FA5-61091C989B40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -266,6 +268,18 @@ Global
 		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|ARM.Build.0 = Release|Any CPU
 		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|x86.ActiveCfg = Release|Any CPU
 		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD}.Release|x86.Build.0 = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|ARM.Build.0 = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Debug|x86.Build.0 = Debug|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|ARM.ActiveCfg = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|ARM.Build.0 = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|x86.ActiveCfg = Release|Any CPU
+		{89CC72A8-43A9-4593-9FA5-61091C989B40}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -288,6 +302,7 @@ Global
 		{99568358-1828-4FB8-9140-506ABE536057} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{CE399B3E-5BC3-40DA-95C5-F83FC9581636} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{E001A600-05B4-4B9B-B35C-5F8A1B302ACD} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{89CC72A8-43A9-4593-9FA5-61091C989B40} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/SmokeTest/FodyWeavers.xsd
+++ b/SmokeTest/FodyWeavers.xsd
@@ -16,6 +16,11 @@
                 <xs:documentation>Used to control if the Dependent properties feature is enabled.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="EnableIsChangedProperty" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to control if the IsChanged property feature is enabled.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="EventInvokerNames" type="xs:string">
               <xs:annotation>
                 <xs:documentation>Used to change the name of the method that fires the notify event. This is a string that accepts multiple values in a comma separated form.</xs:documentation>

--- a/SmokeTest/FodyWeavers.xsd
+++ b/SmokeTest/FodyWeavers.xsd
@@ -11,6 +11,11 @@
                 <xs:documentation>Used to control if the On_PropertyName_Changed feature is enabled.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="TriggerDependentProperties" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to control if the Dependent properties feature is enabled.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="EventInvokerNames" type="xs:string">
               <xs:annotation>
                 <xs:documentation>Used to change the name of the method that fires the notify event. This is a string that accepts multiple values in a comma separated form.</xs:documentation>

--- a/TestAssemblies/AssemblyWithDisabledIsChangedProperty/AssemblyWithDisabledIsChangedProperty.csproj
+++ b/TestAssemblies/AssemblyWithDisabledIsChangedProperty/AssemblyWithDisabledIsChangedProperty.csproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\PropertyChanged\PropertyChanged.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithDisabledIsChangedProperty/IsChangedClassToTest.cs
+++ b/TestAssemblies/AssemblyWithDisabledIsChangedProperty/IsChangedClassToTest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using PropertyChanged;
+
+[SuppressMessage("ReSharper", "NotAccessedField.Global")]
+public class IsChangedClassToTest :
+    INotifyPropertyChanged
+{ 
+    public string Property1 { get; set; }
+
+    public bool IsChanged { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+}

--- a/TestAssemblies/AssemblyWithDisabledTriggerDependentProperties/AssemblyWithDisabledTriggerDependentProperties.csproj
+++ b/TestAssemblies/AssemblyWithDisabledTriggerDependentProperties/AssemblyWithDisabledTriggerDependentProperties.csproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\PropertyChanged\PropertyChanged.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithDisabledTriggerDependentProperties/DependentPropertiesClassToTest.cs
+++ b/TestAssemblies/AssemblyWithDisabledTriggerDependentProperties/DependentPropertiesClassToTest.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using PropertyChanged;
+
+[SuppressMessage("ReSharper", "NotAccessedField.Global")]
+public class DependentPropertiesClassToTest :
+    INotifyPropertyChanged
+{
+    public int OnProperty1ChangedCallCount;
+    public int OnProperty2ChangedCallCount;
+
+    public string Property1 { get; set; }
+    public string Property2 => $"{Property1}";
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public virtual void OnPropertyChanged(string propertyName)
+    {
+        switch(propertyName)
+        {
+            case nameof(Property1):
+                ++OnProperty1ChangedCallCount;
+                break;
+            case nameof(Property2):
+                ++OnProperty2ChangedCallCount;
+                break;
+        }
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Tests/AssemblyWithDisabledIsChangedPropertyTests.cs
+++ b/Tests/AssemblyWithDisabledIsChangedPropertyTests.cs
@@ -1,0 +1,23 @@
+using Fody;
+using System;
+using Xunit;
+
+public class AssemblyWithDisabledIsChangedPropertyTests
+{
+    static TestResult testResult;
+
+    static AssemblyWithDisabledIsChangedPropertyTests()
+    {
+        var weavingTaskFalse = new ModuleWeaver { EnableIsChangedProperty = false };
+        testResult = weavingTaskFalse.ExecuteTestRun("AssemblyWithDisabledIsChangedProperty.dll");
+    }
+
+    [Fact]
+    public void DisabledIsChangedProperty()
+    {
+        var instance = testResult.GetInstance(nameof(IsChangedClassToTest));
+        instance.Property1 = "foo";
+
+        Assert.True(instance.IsChanged != true);
+    }
+}

--- a/Tests/AssemblyWithDisabledTriggerDependentPropertiesTests.cs
+++ b/Tests/AssemblyWithDisabledTriggerDependentPropertiesTests.cs
@@ -1,0 +1,23 @@
+using Fody;
+using Xunit;
+
+public class AssemblyWithDisabledTriggerDependentPropertiesTests
+{
+    static TestResult testResult;
+
+    static AssemblyWithDisabledTriggerDependentPropertiesTests()
+    {
+        var weavingTaskFalse = new ModuleWeaver { TriggerDependentProperties = false };
+        testResult = weavingTaskFalse.ExecuteTestRun("AssemblyWithDisabledTriggerDependentProperties.dll");
+    }
+
+    [Fact]
+    public void TriggerDependentPropertiesDisabled()
+    {
+        var instance = testResult.GetInstance(nameof(DependentPropertiesClassToTest));
+        instance.Property1 = "foo";
+
+        Assert.Equal(1, instance.OnProperty1ChangedCallCount);
+        Assert.Equal(0, instance.OnProperty2ChangedCallCount);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithBeforeAfterInterceptor\AssemblyWithBeforeAfterInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithBlockingClass\AssemblyWithBlockingClass.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledInjectOnPropertyNameChanged\AssemblyWithDisabledInjectOnPropertyNameChanged.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledTriggerDependentProperties\AssemblyWithDisabledTriggerDependentProperties.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInterceptor\AssemblyWithInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithNonVoidOnPropertyNameChanged\AssemblyWithNonVoidOnPropertyNameChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithStackOverflow\AssemblyWithStackOverflow.csproj" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="FodyHelpers" Version="6.2.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />
     <PackageReference Include="XunitContext" Version="1.9.4" />
-    <PackageReference Include="Verify.Xunit" Version="4.2.0" />
+    <PackageReference Include="Verify.Xunit" Version="4.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithBeforeAfterInterceptor\AssemblyWithBeforeAfterInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithBlockingClass\AssemblyWithBlockingClass.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledInjectOnPropertyNameChanged\AssemblyWithDisabledInjectOnPropertyNameChanged.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledIsChangedProperty\AssemblyWithDisabledIsChangedProperty.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledTriggerDependentProperties\AssemblyWithDisabledTriggerDependentProperties.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInterceptor\AssemblyWithInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithNonVoidOnPropertyNameChanged\AssemblyWithNonVoidOnPropertyNameChanged.csproj" />

--- a/Tests/TriggerDependentPropertiesConfigTests.cs
+++ b/Tests/TriggerDependentPropertiesConfigTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Xml.Linq;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class TriggerDependentPropertiesConfigTests :
+    VerifyBase
+{
+    [Fact]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged TriggerDependentProperties='false'/>");
+        var moduleWeaver = new ModuleWeaver {Config = xElement};
+        moduleWeaver.ResolveTriggerDependentPropertiesConfig();
+        Assert.False(moduleWeaver.TriggerDependentProperties);
+    }
+
+    [Fact]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged TriggerDependentProperties='true'/>");
+        var moduleWeaver = new ModuleWeaver {Config = xElement};
+        moduleWeaver.ResolveTriggerDependentPropertiesConfig();
+        Assert.True(moduleWeaver.TriggerDependentProperties);
+    }
+
+    [Fact]
+    public void Default()
+    {
+        var moduleWeaver = new ModuleWeaver();
+        moduleWeaver.ResolveOnPropertyNameChangedConfig();
+        Assert.True(moduleWeaver.TriggerDependentProperties);
+    }    
+
+    public TriggerDependentPropertiesConfigTests(ITestOutputHelper output) :
+        base(output)
+    {
+    }
+}


### PR DESCRIPTION
#### Description
Added an option **TriggerDependentProperties** to the weavers.xml file, set to false will disable the dependency processor.
`<PropertyChanged TriggerDependentProperties='false'/>`


