### PR TITLE
Notify on calls to abstract/virtual base properties

### DIFF
--- a/PropertyChanged.Fody/MappingFinder.cs
+++ b/PropertyChanged.Fody/MappingFinder.cs
@@ -26,6 +26,14 @@ public partial class ModuleWeaver
                                  FieldDefinition = fieldDefinition
                              };
         }
+
+        if (typeDefinition.BaseType != null)
+        {
+            foreach (var mapping in GetMappings(typeDefinition.BaseType.Resolve()))
+            {
+                yield return mapping;
+            }
+        }
     }
 
     static FieldDefinition TryGetField(TypeDefinition typeDefinition, PropertyDefinition property)

--- a/TestAssemblies/AssemblyToProcess/BaseClassForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/BaseClassForInferredShouldAlsoNotifyFor.cs
@@ -1,0 +1,8 @@
+﻿using System.ComponentModel;
+
+public abstract class BaseClassForInferredShouldAlsoNotifyFor : INotifyPropertyChanged
+{
+    public virtual string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/DerivedClassesForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/DerivedClassesForInferredShouldAlsoNotifyFor.cs
@@ -1,0 +1,201 @@
+// Derived classes that inherit Property1 (should not notify for Property2)
+public class DerivedClassNoneEmptyForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+public class DerivedClassEmptyEmptyForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+public class DerivedClassOverrideEmptyForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+public class DerivedClassNewEmptyForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+public class DerivedClassNewVirtualEmptyForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+
+// Derived classes that override Property1 (should notify for Property2)
+public class DerivedClassNoneOverrideForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassEmptyOverrideForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassOverrideOverrideForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+// Not a valid combination of property declarations
+//public class DerivedClassNewOverrideForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+//{
+//    public override string Property1 { get; set; }
+//    public string Property2 => Property1;
+//}
+public class DerivedClassNewVirtualOverrideForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+
+// Derived classes with new Property1 (should notify for Property2)
+public class DerivedClassNoneNewForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassEmptyNewForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassOverrideNewForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassNewNewForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassNewVirtualNewForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+
+// Derived classes with new virtual Property1 (should notify for Property2)
+public class DerivedClassNoneNewVirtualForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassEmptyNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassOverrideNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassNewNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassNewVirtualNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+
+// Derived classes that explicitly call base.Property1 (should not notify for Property2)
+public class DerivedClassNoneEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassEmptyEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassOverrideEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewVirtualEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNoneOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassEmptyOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassOverrideOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+// Not a valid combination of property declarations
+//public class DerivedClassNewOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+//{
+//    public override string Property1 { get; set; }
+//    public string Property2 => base.Property1;
+//}
+public class DerivedClassNewVirtualOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNoneNewExplicitBaseCallForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassEmptyNewExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassOverrideNewExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewNewExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewVirtualNewExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNoneNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassEmptyNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassOverrideNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNewVirtualNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}

--- a/TestAssemblies/AssemblyToProcess/DerivedClassesForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/DerivedClassesForInferredShouldAlsoNotifyFor.cs
@@ -78,27 +78,27 @@ public class DerivedClassNewVirtualNewForInferredShouldAlsoNotifyFor : MiddleCla
 // Derived classes with new virtual Property1 (should notify for Property2)
 public class DerivedClassNoneNewVirtualForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => Property1;
 }
 public class DerivedClassEmptyNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => Property1;
 }
 public class DerivedClassOverrideNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => Property1;
 }
 public class DerivedClassNewNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => Property1;
 }
 public class DerivedClassNewVirtualNewVirtualForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => Property1;
 }
 
@@ -176,26 +176,26 @@ public class DerivedClassNewVirtualNewExplicitBaseCallForInferredShouldAlsoNotif
 }
 public class DerivedClassNoneNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => base.Property1;
 }
 public class DerivedClassEmptyNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassEmptyForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => base.Property1;
 }
 public class DerivedClassOverrideNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassOverrideForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => base.Property1;
 }
 public class DerivedClassNewNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => base.Property1;
 }
 public class DerivedClassNewVirtualNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : MiddleClassNewVirtualForInferredShouldAlsoNotifyFor
 {
-    public new string Property1 { get; set; }
+    public new virtual string Property1 { get; set; }
     public string Property2 => base.Property1;
 }

--- a/TestAssemblies/AssemblyToProcess/DerivedClassesNonvirtualBaseForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/DerivedClassesNonvirtualBaseForInferredShouldAlsoNotifyFor.cs
@@ -1,0 +1,29 @@
+public class DerivedClassNonvirtualBaseNoneForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => Property1;
+}
+public class DerivedClassNonvirtualBaseNewForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+public class DerivedClassNonvirtualBaseNewVirtualNonvirtualBaseForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public new virtual string Property1 { get; set; }
+    public string Property2 => Property1;
+}
+
+public class DerivedClassNonvirtualBaseNoneExplicitBaseCallForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNonvirtualBaseNewExplicitBaseCallForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}
+public class DerivedClassNonvirtualBaseNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor : NonvirtualBaseClassForInferredShouldAlsoNotifyFor
+{
+    public new virtual string Property1 { get; set; }
+    public string Property2 => base.Property1;
+}

--- a/TestAssemblies/AssemblyToProcess/MiddleClassesForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/MiddleClassesForInferredShouldAlsoNotifyFor.cs
@@ -1,0 +1,15 @@
+﻿public class MiddleClassEmptyForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+}
+public class MiddleClassNewForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new string Property1 { get; set; }
+}
+public class MiddleClassNewVirtualForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public new virtual string Property1 { get; set; }
+}
+public class MiddleClassOverrideForInferredShouldAlsoNotifyFor : BaseClassForInferredShouldAlsoNotifyFor
+{
+    public override string Property1 { get; set; }
+}

--- a/TestAssemblies/AssemblyToProcess/NonvirtualBaseClassForInferredShouldAlsoNotifyFor.cs
+++ b/TestAssemblies/AssemblyToProcess/NonvirtualBaseClassForInferredShouldAlsoNotifyFor.cs
@@ -1,0 +1,8 @@
+﻿using System.ComponentModel;
+
+public class NonvirtualBaseClassForInferredShouldAlsoNotifyFor : INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -401,6 +401,43 @@ public class AssemblyToProcessTests
     }
 
     [Fact]
+    public void DerivedClassNonvirtualBaseNoneForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNoneForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+    [Fact]
+    public void DerivedClassNonvirtualBaseNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+    [Fact]
+    public void DerivedClassNonvirtualBaseNewVirtualNonvirtualBaseForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNewVirtualNonvirtualBaseForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+    [Fact]
+    public void DerivedClassNonvirtualBaseNoneExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNoneExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+    [Fact]
+    public void DerivedClassNonvirtualBaseNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+    [Fact]
+    public void DerivedClassNonvirtualBaseNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNonvirtualBaseNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
     public void UseSingleEventInstance()
     {
         var instance = testResult.GetInstance("ClassWithNotifyPropertyChangedAttribute");

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -119,6 +119,288 @@ public class AssemblyToProcessTests
     }
 
     [Fact]
+    public void DerivedClassNoneEmptyForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneEmptyForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNoneOverrideForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneOverrideForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNoneNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNoneNewVirtualForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneNewVirtualForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyEmptyForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyEmptyForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyOverrideForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyOverrideForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyNewVirtualForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyNewVirtualForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideEmptyForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideEmptyForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideOverrideForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideOverrideForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideNewVirtualForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideNewVirtualForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNewEmptyForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewEmptyForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    // Not a valid combination of property declarations
+    //[Fact]
+    //public void DerivedClassNewOverrideForInferredShouldAlsoNotifyFor()
+    //{
+    //    var instance = testResult.GetInstance("DerivedClassNewOverrideForInferredShouldAlsoNotifyFor");
+    //    EventTester.TestProperty(instance, true, property2called: true);
+    //}
+
+    [Fact]
+    public void DerivedClassNewNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNewNewVirtualForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewNewVirtualForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualEmptyForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualEmptyForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualOverrideForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualOverrideForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualNewForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualNewForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualNewVirtualForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualNewVirtualForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: true);
+    }
+
+    [Fact]
+    public void DerivedClassNoneEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNoneOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNoneNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNoneNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNoneNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassEmptyNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassEmptyNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassOverrideNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassOverrideNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    // Not a valid combination of property declarations
+    //[Fact]
+    //public void DerivedClassNewOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    //{
+    //    var instance = testResult.GetInstance("DerivedClassNewOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor");
+    //    EventTester.TestProperty(instance, true, property2called: false);
+    //}
+
+    [Fact]
+    public void DerivedClassNewNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualEmptyExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualOverrideExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualNewExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualNewExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
+    public void DerivedClassNewVirtualNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor()
+    {
+        var instance = testResult.GetInstance("DerivedClassNewVirtualNewVirtualExplicitBaseCallForInferredShouldAlsoNotifyFor");
+        EventTester.TestProperty(instance, true, property2called: false);
+    }
+
+    [Fact]
     public void UseSingleEventInstance()
     {
         var instance = testResult.GetInstance("ClassWithNotifyPropertyChangedAttribute");

--- a/Tests/EventTester.cs
+++ b/Tests/EventTester.cs
@@ -21,7 +21,7 @@ public static class EventTester
         Assert.False(property1EventCalled);
     }
 
-    internal static void TestProperty(dynamic instance, bool checkProperty2, bool delayAfterSetProperty1 = false)
+    internal static void TestProperty(dynamic instance, bool checkProperty2, bool delayAfterSetProperty1 = false, bool property2called = true)
     {
         var property1EventCalled = false;
         var property2EventCalled = false;
@@ -45,9 +45,13 @@ public static class EventTester
         }
 
         Assert.True(property1EventCalled);
-        if (checkProperty2)
+        if (checkProperty2 && property2called)
         {
             Assert.True(property2EventCalled);
+        }
+        else if (checkProperty2 && !property2called)
+        {
+            Assert.False(property2EventCalled);
         }
 
         property1EventCalled = false;

--- a/Tests/IlGeneratedByDependencyReaderTests/WithOverrideAbstractAutoProperties.cs
+++ b/Tests/IlGeneratedByDependencyReaderTests/WithOverrideAbstractAutoProperties.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Xunit;
+
+public class WithOverrideAbstractAutoProperties
+{
+    [Fact]
+    public void Run()
+    {
+        var typeDefinition = DefinitionFinder.FindType<Derived>();
+        var node = new TypeNode
+                       {
+                           TypeDefinition = typeDefinition,
+                           Mappings = ModuleWeaver.GetMappings(typeDefinition).ToList()
+                       };
+        new IlGeneratedByDependencyReader(node).Process();
+        var first = node.PropertyDependencies[0];
+        Assert.Single(node.PropertyDependencies);
+        Assert.Equal("Bar", first.ShouldAlsoNotifyFor.Name);
+        Assert.Equal("Foo", first.WhenPropertyIsSet.Name);
+    }
+
+    public abstract class Base
+    {
+        public abstract bool Foo { get; set; }
+    }
+
+    public class Derived : Base
+    {
+        public override bool Foo { get; set; }
+        public bool Bar => !Foo;
+    }
+}

--- a/Tests/IlGeneratedByDependencyReaderTests/WithOverrideVirtualAutoProperties.cs
+++ b/Tests/IlGeneratedByDependencyReaderTests/WithOverrideVirtualAutoProperties.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Xunit;
+
+public class WithOverrideVirtualAutoProperties
+{
+    [Fact]
+    public void Run()
+    {
+        var typeDefinition = DefinitionFinder.FindType<Derived>();
+        var node = new TypeNode
+                       {
+                           TypeDefinition = typeDefinition,
+                           Mappings = ModuleWeaver.GetMappings(typeDefinition).ToList()
+                       };
+        new IlGeneratedByDependencyReader(node).Process();
+        var first = node.PropertyDependencies[0];
+        Assert.Single(node.PropertyDependencies);
+        Assert.Equal("Bar", first.ShouldAlsoNotifyFor.Name);
+        Assert.Equal("Foo", first.WhenPropertyIsSet.Name);
+    }
+
+    public class Base
+    {
+        public virtual bool Foo { get; set; }
+    }
+
+    public class Derived : Base
+    {
+        public override bool Foo { get; set; }
+        public bool Bar => !Foo;
+    }
+}


### PR DESCRIPTION
This PR resolves issue #635; the code in that issue is now rewritten so that the derived setter for `Foo` notifies about changes to both `Foo` and `Bar`.

#### The solution

First, when scanning for dependencies, also scan for dependencies on base class properties.
Second, when weaving in the change notifications, consider a call to the base class `get_PropertyX` equivalent to a call to the current class `get_PropertyX`, provided (1) the call is a callvirt instruction, and (2) the current class contains a `get_PropertyX`.

I also updated the tests so I could say "When editing Property1, you should _not_ have received a notification about a change to Property2", and used this in many of the new tests I added.

#### Todos

 * [X] Related issues
 * [X] Tests
 * [x] Documentation