### PR TITLE
On-PropName-Changed not called for dependent properties Fixes #700

### DIFF
--- a/PropertyChanged.Fody/OnChangedMethod.cs
+++ b/PropertyChanged.Fody/OnChangedMethod.cs
@@ -11,7 +11,10 @@ public enum OnChangedTypes
 public class OnChangedMethod
 {
     public MethodReference MethodReference;
+    public MethodDefinition MethodDefinition;
     public OnChangedTypes OnChangedType;
     public bool IsDefaultMethod;
     public List<PropertyDefinition> Properties = new();
 }
+
+

--- a/PropertyChanged.Fody/OnChangedMethod.cs
+++ b/PropertyChanged.Fody/OnChangedMethod.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using System.Collections.Generic;
+using Mono.Cecil;
 
 public enum OnChangedTypes
 {
@@ -12,4 +13,5 @@ public class OnChangedMethod
     public MethodReference MethodReference;
     public OnChangedTypes OnChangedType;
     public bool IsDefaultMethod;
+    public List<PropertyDefinition> Properties = new();
 }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -228,19 +228,27 @@ public partial class ModuleWeaver
 
         var baseMessage = $"Type {method.DeclaringType.FullName} contains a method {method.Name} which will not be called";
 
+        // var foundProperty = method.DeclaringType.Properties.FirstOrDefault(p => p.Name == propertyName);
+
         var foundProperty = GetProperty(methodRef, propertyName);
+
+
 
         if (foundProperty == null)
             return $"{baseMessage} as {propertyName} is not found.";
 
+
         if (foundProperty.DeclaringType != method.DeclaringType)
             return $"{baseMessage} as {propertyName} is declared on base class {foundProperty.DeclaringType.Name}.";
+
 
         if (foundProperty.CustomAttributes.ContainsAttribute("PropertyChanged.DoNotNotifyAttribute"))
             return $"{baseMessage} as {propertyName} is attributed with [DoNotNotify].";
 
+
         if (foundProperty.CustomAttributes.ContainsAttribute("PropertyChanged.OnChangedMethodAttribute"))
             return $"{baseMessage} as {propertyName} is attributed with an alternative [OnChangedMethod].";
+
 
         return $"{baseMessage}.";
     }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -228,27 +228,19 @@ public partial class ModuleWeaver
 
         var baseMessage = $"Type {method.DeclaringType.FullName} contains a method {method.Name} which will not be called";
 
-        // var foundProperty = method.DeclaringType.Properties.FirstOrDefault(p => p.Name == propertyName);
-
         var foundProperty = GetProperty(methodRef, propertyName);
-
-
 
         if (foundProperty == null)
             return $"{baseMessage} as {propertyName} is not found.";
 
-
         if (foundProperty.DeclaringType != method.DeclaringType)
             return $"{baseMessage} as {propertyName} is declared on base class {foundProperty.DeclaringType.Name}.";
-
 
         if (foundProperty.CustomAttributes.ContainsAttribute("PropertyChanged.DoNotNotifyAttribute"))
             return $"{baseMessage} as {propertyName} is attributed with [DoNotNotify].";
 
-
         if (foundProperty.CustomAttributes.ContainsAttribute("PropertyChanged.OnChangedMethodAttribute"))
             return $"{baseMessage} as {propertyName} is attributed with an alternative [OnChangedMethod].";
-
 
         return $"{baseMessage}.";
     }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using Fody;
 using Mono.Cecil;
 

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -201,7 +201,13 @@ public partial class ModuleWeaver
             return;
         }
 
-        if (onChangedMethod.Properties.Any())
+        bool PropertyWillBeNotified(PropertyDefinition p)
+        {
+            return notifyNode.PropertyDatas
+                .Any(pd => pd.PropertyDefinition == p || pd.AlsoNotifyFor.Contains(p));
+        }
+
+        if (onChangedMethod.Properties.Any(PropertyWillBeNotified))
         {
             return;
         }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using Fody;
 using Mono.Cecil;
 

--- a/PropertyChanged.Fody/PropertyData.cs
+++ b/PropertyChanged.Fody/PropertyData.cs
@@ -9,5 +9,4 @@ public class PropertyData
     public PropertyDefinition PropertyDefinition;
     public MethodReference EqualsMethod;
     public List<string> AlreadyNotifies = new List<string>();
-    public List<OnChangedMethod> OnChangedMethods = new List<OnChangedMethod>();
 }

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -71,10 +71,10 @@ public class PropertyWeaver
 
     List<OnChangedMethod> GetMethodsForProperty(TypeNode typeNode, PropertyDefinition property)
     {
-        return (from m in typeNode.OnChangedMethods
-            from p in m.Properties
-            where p == property
-            select m).ToList();
+        return (from method in typeNode.OnChangedMethods
+                from prop in method.Properties
+                where prop == property
+                select method).ToList();
     }
 
     IEnumerable<int> FindSetFieldInstructions()

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -60,12 +60,21 @@ public class PropertyWeaver
 
         foreach (var alsoNotifyForDefinition in propertyData.AlsoNotifyFor.Distinct())
         {
-            var data = propertyData.ParentType.PropertyDatas.SingleOrDefault(p => p.PropertyDefinition == alsoNotifyForDefinition);
-            var onChangedMethods = data?.OnChangedMethods ?? new List<OnChangedMethod>();
-            index = AddEventInvokeCall(index, onChangedMethods, alsoNotifyForDefinition);
+            var alsoNotifyMethods = GetMethodsForProperty(propertyData.ParentType, alsoNotifyForDefinition);
+            
+            index = AddEventInvokeCall(index, alsoNotifyMethods, alsoNotifyForDefinition);
         }
 
-        AddEventInvokeCall(index, propertyData.OnChangedMethods, propertyData.PropertyDefinition);
+        var onChangedMethods = GetMethodsForProperty(propertyData.ParentType, propertyData.PropertyDefinition);
+        AddEventInvokeCall(index, onChangedMethods, propertyData.PropertyDefinition);
+    }
+
+    List<OnChangedMethod> GetMethodsForProperty(TypeNode typeNode, PropertyDefinition property)
+    {
+        return (from m in typeNode.OnChangedMethods
+            from p in m.Properties
+            where p == property
+            select m).ToList();
     }
 
     IEnumerable<int> FindSetFieldInstructions()

--- a/PropertyChanged.Fody/TypeNode.cs
+++ b/PropertyChanged.Fody/TypeNode.cs
@@ -19,5 +19,5 @@ public class TypeNode
     public MethodReference IsChangedInvoker;
     public List<PropertyData> PropertyDatas;
     public List<PropertyDefinition> AllProperties;
-    public List<OnChangedMethod> OnChangedMethods;
+    public ICollection<OnChangedMethod> OnChangedMethods;
 }

--- a/PropertyChanged.Fody/TypeNode.cs
+++ b/PropertyChanged.Fody/TypeNode.cs
@@ -19,4 +19,5 @@ public class TypeNode
     public MethodReference IsChangedInvoker;
     public List<PropertyData> PropertyDatas;
     public List<PropertyDefinition> AllProperties;
+    public List<OnChangedMethod> OnChangedMethods;
 }

--- a/TestAssemblies/AssemblyToProcess/ClassWithDependsOnAndPropertyChanged.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithDependsOnAndPropertyChanged.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithDependsOnAndPropertyChanged :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+    [DependsOn("Property1")]
+    public string Property2 { get; set; }
+
+    public int Property2ChangedCalled = 0;
+
+    private void OnProperty2Changed() => Property2ChangedCalled++;
+
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithInvalidOnChanged.cs
@@ -43,7 +43,11 @@ public class ClassWithInvalidOnChanged :
 
     public void OnIgnoredPropertyChanged()
     {
+        OnIgnorePropertyChangedCalled = true;
     }
+
+
+    public bool OnIgnorePropertyChangedCalled = false;
 
     public event PropertyChangedEventHandler PropertyChanged;
 }

--- a/TestAssemblies/AssemblyToProcess/ClassWithOnChangedBeforeAfterCalculatedProperty.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithOnChangedBeforeAfterCalculatedProperty.cs
@@ -14,5 +14,4 @@ public class ClassWithOnChangedBeforeAfterCalculatedProperty
     {
         Property2ChangeValue = $"From {before} to {after}";
     }
-
 }

--- a/TestAssemblies/AssemblyToProcess/ClassWithOnChangedBeforeAfterCalculatedProperty.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithOnChangedBeforeAfterCalculatedProperty.cs
@@ -1,0 +1,18 @@
+using PropertyChanged;
+
+[AddINotifyPropertyChangedInterface]
+public class ClassWithOnChangedBeforeAfterCalculatedProperty
+{
+
+    public string Property1 { get; set; }
+    public int Property2 => Property1?.Length ?? 0;
+
+    public string Property2ChangeValue;
+    
+
+    public void OnProperty2Changed(object before, object after)
+    {
+        Property2ChangeValue = $"From {before} to {after}";
+    }
+
+}

--- a/TestAssemblies/AssemblyToProcess/ClassWithOnChangedCalculatedProperty.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithOnChangedCalculatedProperty.cs
@@ -4,13 +4,20 @@ public class ClassWithOnChangedCalculatedProperty :
     INotifyPropertyChanged
 {
     public bool OnProperty2ChangedCalled;
+    public bool OnProperty3ChangedCalled;
 
     public string Property1 { get; set; }
     public string Property2 => $"{Property1}!";
-
+    public string Property3 => $"{Property2}!";
+    
     public void OnProperty2Changed()
     {
         OnProperty2ChangedCalled = true;
+    }
+
+    public void OnProperty3Changed()
+    {
+        OnProperty3ChangedCalled = true;
     }
 
     public event PropertyChangedEventHandler PropertyChanged;

--- a/TestAssemblies/AssemblyToProcess/ClassWithOnChangedCalculatedProperty.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithOnChangedCalculatedProperty.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+
+public class ClassWithOnChangedCalculatedProperty :
+    INotifyPropertyChanged
+{
+    public bool OnProperty2ChangedCalled;
+
+    public string Property1 { get; set; }
+    public string Property2 => $"{Property1}!";
+
+    public void OnProperty2Changed()
+    {
+        OnProperty2ChangedCalled = true;
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/ClassWithWarnings.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithWarnings.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics;
+using PropertyChanged;
+
+
+[AddINotifyPropertyChangedInterface]
+public class ClassWithWarningsBase
+{
+    public string BaseClassProperty { get; set; }
+}
+
+[AddINotifyPropertyChangedInterface]
+public class ClassWithWarnings : ClassWithWarningsBase
+{
+
+    [DoNotNotify]
+    public string Property1 { get; set; }
+
+    [OnChangedMethod(nameof(CallThisInstead))]
+    public string Property2 { get; set; }
+
+    public bool Property1ChangedCalled;
+    public bool Property2ChangedCalled;
+    public bool PropertyXChangedCalled;
+    public bool CallThisInsteadCalled;
+
+
+    void OnProperty1Changed() => Trace.WriteLine("Ignored");
+
+    void OnProperty2Changed() => Trace.WriteLine("Ignored");
+
+    void OnPropertyXChanged() => Trace.WriteLine("Ignored");
+    void OnBaseClassPropertyChanged() => Trace.WriteLine("Ignored");
+
+    void CallThisInstead() => Trace.WriteLine("Ignored");
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -240,6 +240,28 @@ public class AssemblyToProcessTests
     }
 
     [Fact]
+    public void ClassWithWarnings()
+    {
+        var instance = testResult.GetInstance("ClassWithWarnings");
+        instance.Property1 = "foo";
+
+        var warnings = testResult.Warnings
+            .Where(w => w.Text.ContainsWholeWord("ClassWithWarnings"))
+            .Select(w => w.Text.Replace(" You can suppress this warning with [SuppressPropertyChangedWarnings].", ""))
+            .ToArray();
+
+        outputHelper.WriteLine(string.Join(Environment.NewLine, warnings.Select(w => $"\"{w}\"")));
+
+        Assert.Equal(warnings, new[]
+        {
+            "Type ClassWithWarnings contains a method OnProperty1Changed which will not be called as Property1 is attributed with [DoNotNotify].",
+            "Type ClassWithWarnings contains a method OnProperty2Changed which will not be called as Property2 is attributed with an alternative [OnChangedMethod].",
+            "Type ClassWithWarnings contains a method OnPropertyXChanged which will not be called as PropertyX is not found.",
+            "Type ClassWithWarnings contains a method OnBaseClassPropertyChanged which will not be called as BaseClassProperty is declared on base class ClassWithWarningsBase."
+        });
+    }
+
+    [Fact]
     public void OnPropertyNameChangedMethodWithoutMatchingPropertyEmitsWarning()
     {
         const string className = nameof(ClassWithInvalidOnChanged);

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -313,7 +313,7 @@ public class AssemblyToProcessTests
         var instance = testResult.GetInstance(nameof(ClassWithOnChangedBeforeAfterCalculatedProperty));
         instance.Property1 = "foo";
 
-        DumpWarnings();
+        DumpWarnings(nameof(ClassWithOnChangedBeforeAfterCalculatedProperty));
 
         Assert.Equal("From 0 to 3", instance.Property2ChangeValue);
         Assert.DoesNotContain(testResult.Warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedBeforeAfterCalculatedProperty)));

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -294,7 +294,8 @@ public class AssemblyToProcessTests
         instance.Property1 = "foo";
 
         Assert.True(instance.OnProperty2ChangedCalled);
-        Assert.DoesNotContain(testResult.Warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChanged)));
+        Assert.True(instance.OnProperty3ChangedCalled);
+        Assert.DoesNotContain(testResult.Warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedCalculatedProperty)));
     }
 
     [Fact]
@@ -347,13 +348,14 @@ public class AssemblyToProcessTests
     [Fact]
     public void ClassWithOnChangedCustomizedWarnings()
     {
-        DumpWarnings(nameof(ClassWithOnChangedCustomized));
-        
-        Assert.Contains(testResult.Warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedCustomized))
-                                                  && w.Text.Contains(nameof(ClassWithOnChangedCustomized.OnProperty1Changed)));
+        var warnings = testResult.Warnings
+            .Where(w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedCustomized)))
+            .ToArray();
 
-        Assert.DoesNotContain(testResult.Warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedCustomized))
-                                                        && !w.Text.Contains(nameof(ClassWithOnChangedCustomized.Property1)));
+        Assert.Contains(warnings, w => w.Text.ContainsWholeWord(nameof(ClassWithOnChangedCustomized))
+                                       && w.Text.Contains(nameof(ClassWithOnChangedCustomized.OnProperty1Changed)));
+
+        Assert.True(warnings.Length == 1);
     }
 
 

--- a/Tests/AssemblyWithInheritanceTests.cs
+++ b/Tests/AssemblyWithInheritanceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 #if NETCOREAPP
@@ -44,64 +43,64 @@ public class AssemblyWithInheritanceTests
 
     [Theory]
     [InlineData(0, "DerivedClass", "Property1", 
-        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" },
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed" },
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
     
     [InlineData(0, "DerivedClass", "Property2", 
-        new[] { "Property5", "derived:OnProperty2Changed", "Property2" }, 
+        new[] {                               "Property5", "derived:OnProperty2Changed", "Property2" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
     
     [InlineData(0, "DerivedClass", "Property3", 
-        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
     
     [InlineData(0, "DerivedNoOverrides", "Property1", 
-        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
     
     [InlineData(0, "DerivedNoOverrides", "Property2", 
-        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
     
     [InlineData(0, "DerivedNoOverrides", "Property3", 
-        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
    
     [InlineData(0, "DerivedDerivedClass", "Property1",
-        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed", "Property6", "derived++:OnProperty1Changed" }, 
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed",                                 "Property6", "derived++:OnProperty1Changed" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty1Changed"
         })]
     
     [InlineData(0, "DerivedDerivedClass", "Property2", 
-        new[] { "Property6", "derived++:OnProperty2Changed", "Property2" }, 
+        new[] {                                 "Property6", "derived++:OnProperty2Changed", "Property2" }, 
         new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty2Changed", "Property2" })]
     
     [InlineData(0, "DerivedDerivedClass", "Property3", 
-        new[] { "Property6", "derived++:OnProperty3Changed", "Property3" }, 
+        new[] {                                 "Property6", "derived++:OnProperty3Changed", "Property3" }, 
         new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty3Changed", "Property3" })]
     
     [InlineData(1, "DerivedClass", "Property1", 
-        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" }, 
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
     
     [InlineData(1, "DerivedClass", "Property2", 
-        new[] { "Property5", "derived:OnProperty2Changed", "Property2" }, 
+        new[] {                               "Property5", "derived:OnProperty2Changed", "Property2" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
     
     [InlineData(1, "DerivedClass", "Property3", 
-        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
     
     [InlineData(1, "DerivedNoOverrides", "Property1",
-        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
    
     [InlineData(1, "DerivedNoOverrides", "Property2", 
-        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
     
     [InlineData(1, "DerivedNoOverrides", "Property3", 
-        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
     
     [InlineData(0, "PocoBase", "Property1", 
@@ -109,23 +108,23 @@ public class AssemblyWithInheritanceTests
         new string[0])]
     
     [InlineData(0, "DerivedFromPoco", "Property1", 
-        new[] { "Property4", "derived:OnProperty1Changed", "Property1" }, 
+        new[] {                               "Property4", "derived:OnProperty1Changed", "Property1" }, 
         new[] { "derived:OnProperty4Changed", "Property4", "derived:OnProperty1Changed", "Property1" })]
     
     [InlineData(0, "DerivedNewProperties", "Property1", 
-        new[] { "Property5", "derived:OnProperty1Changed", "Property1" }, 
+        new[] {                               "Property5", "derived:OnProperty1Changed", "Property1" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "Property1" })]
     
     [InlineData(0, "DerivedNewProperties", "Property2", 
-        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
     
     [InlineData(0, "DerivedNewProperties", "Property3", 
-        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
         new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
    
     [InlineData(0, "DerivedCallingChild", "Property1", 
-        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
         new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
    
     [InlineData(0, "DerivedCallingChild", "Property2", 
@@ -158,4 +157,6 @@ public class AssemblyWithInheritanceTests
 
     readonly ITestOutputHelper outputHelper;
     static Assembly[] assemblies;
+    
+    
 }

--- a/Tests/AssemblyWithInheritanceTests.cs
+++ b/Tests/AssemblyWithInheritanceTests.cs
@@ -42,95 +42,29 @@ public class AssemblyWithInheritanceTests
     }
 
     [Theory]
-    [InlineData(0, "DerivedClass", "Property1", 
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed" },
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
-    
-    [InlineData(0, "DerivedClass", "Property2", 
-        new[] {                               "Property5", "derived:OnProperty2Changed", "Property2" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(0, "DerivedClass", "Property3", 
-        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
-    
-    [InlineData(0, "DerivedNoOverrides", "Property1", 
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
-    
-    [InlineData(0, "DerivedNoOverrides", "Property2", 
-        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(0, "DerivedNoOverrides", "Property3", 
-        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
-   
-    [InlineData(0, "DerivedDerivedClass", "Property1",
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed",                                 "Property6", "derived++:OnProperty1Changed" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty1Changed"
-        })]
-    
-    [InlineData(0, "DerivedDerivedClass", "Property2", 
-        new[] {                                 "Property6", "derived++:OnProperty2Changed", "Property2" }, 
-        new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(0, "DerivedDerivedClass", "Property3", 
-        new[] {                                 "Property6", "derived++:OnProperty3Changed", "Property3" }, 
-        new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty3Changed", "Property3" })]
-    
-    [InlineData(1, "DerivedClass", "Property1", 
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1",                               "Property5", "derived:OnProperty1Changed" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
-    
-    [InlineData(1, "DerivedClass", "Property2", 
-        new[] {                               "Property5", "derived:OnProperty2Changed", "Property2" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(1, "DerivedClass", "Property3", 
-        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
-    
-    [InlineData(1, "DerivedNoOverrides", "Property1",
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
-   
-    [InlineData(1, "DerivedNoOverrides", "Property2", 
-        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(1, "DerivedNoOverrides", "Property3", 
-        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
-    
-    [InlineData(0, "PocoBase", "Property1", 
-        new string[0], 
-        new string[0])]
-    
-    [InlineData(0, "DerivedFromPoco", "Property1", 
-        new[] {                               "Property4", "derived:OnProperty1Changed", "Property1" }, 
-        new[] { "derived:OnProperty4Changed", "Property4", "derived:OnProperty1Changed", "Property1" })]
-    
-    [InlineData(0, "DerivedNewProperties", "Property1", 
-        new[] {                               "Property5", "derived:OnProperty1Changed", "Property1" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "Property1" })]
-    
-    [InlineData(0, "DerivedNewProperties", "Property2", 
-        new[] {                            "Property4", "base:OnProperty2Changed", "Property2" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
-    
-    [InlineData(0, "DerivedNewProperties", "Property3", 
-        new[] {                               "Property5", "derived:OnProperty3Changed", "Property3" }, 
-        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
-   
-    [InlineData(0, "DerivedCallingChild", "Property1", 
-        new[] {                            "Property4", "base:OnProperty1Changed", "Property1" }, 
-        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
-   
-    [InlineData(0, "DerivedCallingChild", "Property2", 
-        new[] { "Property2" }, 
-        new[] { "Property2" })]
-    public void DerivedClassRaisesAllExpectedEvents(int assemblyIndex, string className, string propertyName, string[] previouslyExpected, string[] expected)
+    [InlineData(0, "DerivedClass", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
+    [InlineData(0, "DerivedClass", "Property2", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
+    [InlineData(0, "DerivedClass", "Property3", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    [InlineData(0, "DerivedNoOverrides", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedNoOverrides", "Property2", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    [InlineData(0, "DerivedNoOverrides", "Property3", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    [InlineData(0, "DerivedDerivedClass", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty1Changed"})]
+    [InlineData(0, "DerivedDerivedClass", "Property2", new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty2Changed", "Property2" })]
+    [InlineData(0, "DerivedDerivedClass", "Property3", new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty3Changed", "Property3" })]
+    [InlineData(1, "DerivedClass", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
+    [InlineData(1, "DerivedClass", "Property2", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
+    [InlineData(1, "DerivedClass", "Property3", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    [InlineData(1, "DerivedNoOverrides", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+    [InlineData(1, "DerivedNoOverrides", "Property2", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    [InlineData(1, "DerivedNoOverrides", "Property3", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    [InlineData(0, "PocoBase", "Property1", new string[0])]
+    [InlineData(0, "DerivedFromPoco", "Property1", new[] { "derived:OnProperty4Changed", "Property4", "derived:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedNewProperties", "Property1", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedNewProperties", "Property2", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    [InlineData(0, "DerivedNewProperties", "Property3", new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    [InlineData(0, "DerivedCallingChild", "Property1", new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedCallingChild", "Property2", new[] { "Property2" })]
+    public void DerivedClassRaisesAllExpectedEvents(int assemblyIndex, string className, string propertyName, string[] expected)
     {
         var assembly = assemblies[assemblyIndex];
         var instanceType = assembly.GetType(className);
@@ -143,12 +77,10 @@ public class AssemblyWithInheritanceTests
         
         var act = string.Join(", ", actual.Select(item => $"\"{item}\""));
         var exp = string.Join(", ", expected.Select(item => $"\"{item}\""));
-        var prevExp = string.Join(", ", previouslyExpected.Select(item => $"\"{item}\""));
 
         outputHelper.WriteLine(assembly.CodeBase);
         outputHelper.WriteLine("");
-        outputHelper.WriteLine($"OLD EXPECTED {prevExp}");
-        outputHelper.WriteLine($"NEW EXPECTED {exp}");
+        outputHelper.WriteLine($"EXPECTED {exp}");
         outputHelper.WriteLine($"ACTUAL       {act}");
         outputHelper.WriteLine("");
 

--- a/Tests/AssemblyWithInheritanceTests.cs
+++ b/Tests/AssemblyWithInheritanceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 #if NETCOREAPP
@@ -42,40 +43,115 @@ public class AssemblyWithInheritanceTests
     }
 
     [Theory]
-    [InlineData(0, "DerivedClass", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" })]
-    [InlineData(0, "DerivedClass", "Property2", new[] { "Property5", "derived:OnProperty2Changed", "Property2" })]
-    [InlineData(0, "DerivedClass", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
-    [InlineData(0, "DerivedNoOverrides", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1" })]
-    [InlineData(0, "DerivedNoOverrides", "Property2", new[] { "Property4", "base:OnProperty2Changed", "Property2" })]
-    [InlineData(0, "DerivedNoOverrides", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
-    [InlineData(0, "DerivedDerivedClass", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed", "Property6", "derived++:OnProperty1Changed" })]
-    [InlineData(0, "DerivedDerivedClass", "Property2", new[] { "Property6", "derived++:OnProperty2Changed", "Property2" })]
-    [InlineData(0, "DerivedDerivedClass", "Property3", new[] { "Property6", "derived++:OnProperty3Changed", "Property3" })]
-    [InlineData(1, "DerivedClass", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" })]
-    [InlineData(1, "DerivedClass", "Property2", new[] { "Property5", "derived:OnProperty2Changed", "Property2" })]
-    [InlineData(1, "DerivedClass", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
-    [InlineData(1, "DerivedNoOverrides", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1" })]
-    [InlineData(1, "DerivedNoOverrides", "Property2", new[] { "Property4", "base:OnProperty2Changed", "Property2" })]
-    [InlineData(1, "DerivedNoOverrides", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
-    [InlineData(0, "PocoBase", "Property1", new string[0])]
-    [InlineData(0, "DerivedFromPoco", "Property1", new[] { "Property4", "derived:OnProperty1Changed", "Property1" })]
-    [InlineData(0, "DerivedNewProperties", "Property1", new[] { "Property5", "derived:OnProperty1Changed", "Property1" })]
-    [InlineData(0, "DerivedNewProperties", "Property2", new[] { "Property4", "base:OnProperty2Changed", "Property2" })]
-    [InlineData(0, "DerivedNewProperties", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
-    [InlineData(0, "DerivedCallingChild", "Property1", new[] { "Property4", "base:OnProperty1Changed", "Property1" })]
-    [InlineData(0, "DerivedCallingChild", "Property2", new[] { "Property2" })]
-    public void DerivedClassRaisesAllExpectedEvents(int assemblyIndex, string className, string propertyName, string[] expected)
+    [InlineData(0, "DerivedClass", "Property1", 
+        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" },
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
+    
+    [InlineData(0, "DerivedClass", "Property2", 
+        new[] { "Property5", "derived:OnProperty2Changed", "Property2" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(0, "DerivedClass", "Property3", 
+        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    
+    [InlineData(0, "DerivedNoOverrides", "Property1", 
+        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+    
+    [InlineData(0, "DerivedNoOverrides", "Property2", 
+        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(0, "DerivedNoOverrides", "Property3", 
+        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+   
+    [InlineData(0, "DerivedDerivedClass", "Property1",
+        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed", "Property6", "derived++:OnProperty1Changed" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty1Changed"
+        })]
+    
+    [InlineData(0, "DerivedDerivedClass", "Property2", 
+        new[] { "Property6", "derived++:OnProperty2Changed", "Property2" }, 
+        new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(0, "DerivedDerivedClass", "Property3", 
+        new[] { "Property6", "derived++:OnProperty3Changed", "Property3" }, 
+        new[] { "derived++:OnProperty6Changed", "Property6", "derived++:OnProperty3Changed", "Property3" })]
+    
+    [InlineData(1, "DerivedClass", "Property1", 
+        new[] { "Property4", "base:OnProperty1Changed", "Property1", "Property5", "derived:OnProperty1Changed" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1", "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed" })]
+    
+    [InlineData(1, "DerivedClass", "Property2", 
+        new[] { "Property5", "derived:OnProperty2Changed", "Property2" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(1, "DerivedClass", "Property3", 
+        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    
+    [InlineData(1, "DerivedNoOverrides", "Property1",
+        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+   
+    [InlineData(1, "DerivedNoOverrides", "Property2", 
+        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(1, "DerivedNoOverrides", "Property3", 
+        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+    
+    [InlineData(0, "PocoBase", "Property1", 
+        new string[0], 
+        new string[0])]
+    
+    [InlineData(0, "DerivedFromPoco", "Property1", 
+        new[] { "Property4", "derived:OnProperty1Changed", "Property1" }, 
+        new[] { "derived:OnProperty4Changed", "Property4", "derived:OnProperty1Changed", "Property1" })]
+    
+    [InlineData(0, "DerivedNewProperties", "Property1", 
+        new[] { "Property5", "derived:OnProperty1Changed", "Property1" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty1Changed", "Property1" })]
+    
+    [InlineData(0, "DerivedNewProperties", "Property2", 
+        new[] { "Property4", "base:OnProperty2Changed", "Property2" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty2Changed", "Property2" })]
+    
+    [InlineData(0, "DerivedNewProperties", "Property3", 
+        new[] { "Property5", "derived:OnProperty3Changed", "Property3" }, 
+        new[] { "derived:OnProperty5Changed", "Property5", "derived:OnProperty3Changed", "Property3" })]
+   
+    [InlineData(0, "DerivedCallingChild", "Property1", 
+        new[] { "Property4", "base:OnProperty1Changed", "Property1" }, 
+        new[] { "base:OnProperty4Changed", "Property4", "base:OnProperty1Changed", "Property1" })]
+   
+    [InlineData(0, "DerivedCallingChild", "Property2", 
+        new[] { "Property2" }, 
+        new[] { "Property2" })]
+    public void DerivedClassRaisesAllExpectedEvents(int assemblyIndex, string className, string propertyName, string[] previouslyExpected, string[] expected)
     {
         var assembly = assemblies[assemblyIndex];
         var instanceType = assembly.GetType(className);
         var instance = (dynamic)Activator.CreateInstance(instanceType);
 
-        var actual = (IList<string>)instance.Notifications;
-
+        
         instanceType.GetProperty(propertyName)?.SetValue(instance, 42);
 
+        var actual = (IList<string>)instance.Notifications;
+        
+        var act = string.Join(", ", actual.Select(item => $"\"{item}\""));
+        var exp = string.Join(", ", expected.Select(item => $"\"{item}\""));
+        var prevExp = string.Join(", ", previouslyExpected.Select(item => $"\"{item}\""));
+
         outputHelper.WriteLine(assembly.CodeBase);
-        outputHelper.WriteLine(string.Join(", ", actual.Select(item => $"\"{item}\"")));
+        outputHelper.WriteLine("");
+        outputHelper.WriteLine($"OLD EXPECTED {prevExp}");
+        outputHelper.WriteLine($"NEW EXPECTED {exp}");
+        outputHelper.WriteLine($"ACTUAL       {act}");
+        outputHelper.WriteLine("");
 
         Assert.Equal(expected, actual);
     }


### PR DESCRIPTION
Hi, new Patron here, just signed up.  Also I've used SVN most of my software dev career so completely new to git/github so go easy if I haven't done something quite right.


#### Description

The 3.2.0 release introduced a bug whereby calculated properties would no longer raise an On-Property-Changed() call, so for example:

```
public string Property1 { get; set; }
public string Property2 => $"{Property1}!";

public void OnProperty2Changed() => Console.WriteLine("Property 2 has changed");
```

OnProperty2Changed() is no longer called, despite OnPropertyChanged being raised for Property2;

#### The solution

3.2.0 moved storage of OnChangedMethods from TypeNode to TypeNode.PropertyData, which is problematic because this collection only contains those properties which are to have their setters modified.  As a calculated property such as Property2 above has no setter, it could not have an associated list of OnChangedMethods.  This is why adding an empty setter to Property2 fixes the problem, such as 

`public string Property2{ get => $"{Property1}!"; set {}} `

To fix this I've moved OnChangedMethods back to TypeNode, and added `public List<PropertyDefinition> Properties` to OnChangedMethod.  This stores against each method, the PropertyDefinitions which should cause each method to be called.  Originally I made this a `HashSet<PropertyDefinition>` but this failed a test which verifies multiple calls to the same change method.

`OnChangedWalker.cs` has been modified to find the `OnChangedMethod`s and register the properties which should cause each to be called.

`PropertyWeaver.InjectAtIndex` is modified to source the OnChangedMethods from `TypeNode.OnChangedMethods` rather than `PropertyData.OnChangedMethods`.

I was going to add a new test but the existing test class `AssemblyWithInheritanceTests` actually covers this, though I think the expectations are all incorrect because they excluded all the `On-MyCalculatedProp-Changed` calls.  To that end, I've modified the test to show OLD EXPECTED and NEW EXPECTED.  The NEW EXPECTED values I've just copied from test output, so while the tests pass, each really needs an individual sanity check to confirm it is correct.

I haven't done this yet as I'd like some input from others before proceeding.  There may be some way I've misunderstood what's going on.


#### Todos

 * [x] Verify expectations in `AssemblyWithInheritanceTests`
 * [x] Remove previouslyExpected from `AssemblyWithInheritanceTests` after correctness is verified
 * [x] Fix where no longer applies: Warning : Fody/PropertyChanged: Type XYZ does not contain a Length property with an injected change notification, and therefore the OnLengthChanged method will not be called...