### PR TITLE
Remove the ret instruction for keep to the behaviour of setter defined.

### DIFF
--- a/PropertyChanged.Fody/PropertyChanged.Fody.csproj
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>3.4.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.6.0" />

--- a/PropertyChanged/PropertyChanged.csproj
+++ b/PropertyChanged/PropertyChanged.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net48;net60;netstandard1.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
@@ -12,6 +12,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/Fody/PropertyChanged/master/package_icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Fody/PropertyChanged</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>3.4.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.6.0" PrivateAssets="none" />

--- a/SmokeTest/BaseEntity.cs
+++ b/SmokeTest/BaseEntity.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace SmokeTest
+{
+    public class BaseEntity : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public virtual void OnPropertyChanged(string text1)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(text1));
+        }
+    }
+}

--- a/SmokeTest/BoxInterne.cs
+++ b/SmokeTest/BoxInterne.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace SmokeTest
+{
+    public abstract class BoxBase : BaseEntity
+    {
+        public int A { get; set; }
+        public int B { get; set; }
+        public int C { get; set; }
+        public IList<BoxBase> Boxes { get; set; }
+
+        public BoxBase()
+        {
+            A = 5;
+            B = 7;
+            C = 9;
+            Boxes = new List<BoxBase>();
+        }
+    }
+
+    public class BoxInterne : BoxBase
+    {
+        public int V => A * B * C;
+    }
+}

--- a/SmokeTest/CheckInsertIL.cs
+++ b/SmokeTest/CheckInsertIL.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace SmokeTest
+{
+    public class CheckInsertIL : INotifyPropertyChanged
+    {
+        private string _stringProperty = "Hello the World";
+        public string StringProperty 
+        { 
+            get => _stringProperty;
+            set => _stringProperty = "Bonjour le monde";
+        }
+
+        private int _intBeforeValue = 0;
+        public int CheckIntBeforeValue => _intBeforeValue;
+        private int _intAfterValue = 0;
+        public int CheckIntAfterValue => _intAfterValue;
+
+        private int _intProperty = 256;
+        public int IntProperty 
+        {
+            get => _intProperty;
+            set
+            {
+                _intBeforeValue = int.MaxValue;
+                _intProperty = value;
+                _intAfterValue = -_intProperty;
+            }
+        }
+
+        private BoxBase _box;
+        public BoxBase Box
+        {
+            get => _box;
+            set
+            {
+                _box = value;
+                _box.A = 9;
+                _box.B = 10;
+                _box.C = 11;
+            }
+        }
+
+        public CheckInsertIL()
+        {
+            _box = new BoxInterne();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public void RaisePropertyChanged(string name = "")
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(name));
+            }
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -13,6 +13,7 @@
     <Reference Include="Microsoft.CSharp" />
     <ProjectReference Include="..\PropertyChanged.Fody\PropertyChanged.Fody.csproj" />
     <ProjectReference Include="..\PropertyChanged\PropertyChanged.csproj" />
+    <ProjectReference Include="..\SmokeTest\SmokeTest.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyExplicitPropertyChanged\AssemblyExplicitPropertyChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyInheritingBadNamedInvoker\AssemblyInheritingBadNamedInvoker.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyToProcess\AssemblyToProcess.csproj" />

--- a/Tests/VerifySetPropertyAlreadyDefinedTests.cs
+++ b/Tests/VerifySetPropertyAlreadyDefinedTests.cs
@@ -1,0 +1,47 @@
+﻿using Xunit;
+using SmokeTest;
+
+namespace Tests
+{
+    public class VerifySetPropertyAlreadyDefinedTests
+    {
+        /// <summary>
+        /// The instruction after the copy of value must to executed,
+        /// even if it's the same reference value.
+        /// </summary>
+        [Fact]
+        public void InstructionAfterValueCheckBox()
+        {
+            CheckInsertIL checkInsertIL = new();
+            Assert.Equal(5 * 7 * 9, (checkInsertIL.Box as BoxInterne).V);
+            checkInsertIL.Box = checkInsertIL.Box;
+            Assert.Equal(9 * 10 * 11, (checkInsertIL.Box as BoxInterne).V);
+        }
+
+        /// <summary>
+        /// The string must to be changed even if it's the same string and haven't copy
+        /// the value to the backing field.
+        /// </summary>
+        [Fact]
+        public void InstructionSameValueCheckString()
+        {
+            CheckInsertIL checkInsert = new();
+            checkInsert.StringProperty = "Hello the World";
+            Assert.NotEqual("Hello the World", checkInsert.StringProperty);
+        }
+
+        /// <summary>
+        /// The instruction before the copy of value must to be executed,
+        /// even if it's the same value.
+        /// The instruction must to be executed after the copy of value.
+        /// </summary>
+        [Fact]
+        public void InstructionBeforeValueCheckInt()
+        {
+            CheckInsertIL checkInsert = new();
+            checkInsert.IntProperty = 256;
+            Assert.True(checkInsert.CheckIntBeforeValue == int.MaxValue);
+            Assert.True(checkInsert.CheckIntAfterValue == -256);
+        }
+    }
+}


### PR DESCRIPTION
----
Let the responsability at the developer to execute any instructions into setter property.
----
Actually the real behavior of CIL injected of the PropertyChanged is below :

Auto-property (it's fine)
```C#
set 
{
if (System.Object.Equals(_backendfield, value) == true) // injected CIL
    return; // injected CIL
_backendfield = value;
RaisePropertyChanged(propertyName); // injected CIL
}
```

Setter with body (unattended behavior : instructions not executed)
```C#
private bool _classFictif;
private object obj;
set
{
if (System.Object.Equals(obj, value) == true) // injected CIL
    return; // injected CIL
_classFictif = value is ClassFictif; // from here the instructions are never executed if equals is true.
obj = value;
if(_classFictif)
   obj.PropFictif = "hello the world";
RaisePropertyChanged(propertyName); // injected CIL
}
```

This PR change slightly the method for evaluate if the trigger should to be executed.
I create a local variable to keep the result of equals method and test this variable just before the insertion of RaisePropertyChanged.
Return only at the end of property (unless the developer adds a return statement).
```C#
set
{
bool result = (System.Object.Equals(_backendField, value); // injected CIL
/*
Any instructions
*/
if(result == false)
    RaisePropertyChanged(propertyName);  // injected CIL
}
```
