### PR TITLE
Support [DoNotNotify] on fields

### DIFF
--- a/PropertyChanged.Fody/PropertyDataWalker.cs
+++ b/PropertyChanged.Fody/PropertyDataWalker.cs
@@ -40,6 +40,12 @@ public partial class ModuleWeaver
             .Select(x => x.ShouldAlsoNotifyFor);
 
         var backingFieldReference = node.Mappings.First(x => x.PropertyDefinition == propertyDefinition).FieldDefinition;
+
+        if (backingFieldReference?.CustomAttributes.ContainsAttribute("PropertyChanged.DoNotNotifyAttribute") == true)
+        {
+            return;
+        }
+
         if (notifyPropertyData == null)
         {
             if (node.EventInvoker == null)

--- a/TestAssemblies/AssemblyToProcess/ClassWithDoNotNotifyField.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithDoNotNotifyField.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithDoNotNotifyField :
+    INotifyPropertyChanged
+{
+    [field: DoNotNotify]
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -136,6 +136,13 @@ public class AssemblyToProcessTests
     }
 
     [Fact]
+    public void ClassWithDoNotNotifyField()
+    {
+        var instance = testResult.GetInstance(nameof(ClassWithDoNotNotifyField));
+        EventTester.TestPropertyNotCalled(instance);
+    }
+
+    [Fact]
     public void UseSingleEventInstance()
     {
         var instance = testResult.GetInstance("ClassWithNotifyPropertyChangedAttribute");


### PR DESCRIPTION
This skips a property if its backing field is marked as `[DoNotNotify]`.

This attribute can target fields, but the weaver currently ignores that. We should either add support (which this PR does), or remove the field target for consistency. I'm not sure which option is better, but since the change is trivial and helps someone, I figured why not just support this? 🙂 

Closes #846
