### PR TITLE
Fix codegen for value types

### DIFF
--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -118,6 +118,7 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         instructions.Add(Instruction.Create(OpCodes.Ldfld, fsharpEvent));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.AddConditionalBoxInstructions(targetType);
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Newobj, PropertyChangedEventConstructorReference));
         instructions.Add(Instruction.Create(OpCodes.Tail));
@@ -147,6 +148,7 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Brfalse_S, last));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.AddConditionalBoxInstructions(targetType);
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Newobj, PropertyChangedEventConstructorReference));
         instructions.Add(Instruction.Create(OpCodes.Tail));
@@ -177,6 +179,7 @@ public partial class ModuleWeaver
         instructions.Add(Instruction.Create(OpCodes.Brfalse_S, last));
         instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.AddConditionalBoxInstructions(targetType);
         instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
         instructions.Add(Instruction.Create(OpCodes.Tail));
         instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -357,7 +357,10 @@ public class PropertyWeaver
             method = genericMethod;
         }
 
-        var instructionList = new List<Instruction> { Instruction.Create(OpCodes.Callvirt, method) };
+        var instructionList = new List<Instruction>
+        {
+            Instruction.Create(typeNode.TypeDefinition.GetCallOpCode(), method)
+        };
 
         if (method.ReturnType.FullName != typeSystem.VoidReference.FullName)
         {
@@ -369,11 +372,11 @@ public class PropertyWeaver
 
     public Instruction CreateIsChangedInvoker()
     {
-        return Instruction.Create(OpCodes.Callvirt, typeNode.IsChangedInvoker);
+        return Instruction.Create(typeNode.TypeDefinition.GetCallOpCode(), typeNode.IsChangedInvoker);
     }
 
     public Instruction CreateCall(MethodReference methodReference)
     {
-        return Instruction.Create(OpCodes.Callvirt, methodReference);
+        return Instruction.Create(typeNode.TypeDefinition.GetCallOpCode(), methodReference);
     }
 }

--- a/PropertyChanged/AddINotifyPropertyChangedInterfaceAttribute.cs
+++ b/PropertyChanged/AddINotifyPropertyChangedInterfaceAttribute.cs
@@ -9,7 +9,7 @@ namespace PropertyChanged
     /// injected irrespective of the use of this attribute.
     /// Raising an issue about "this attribute does not behave as expected" will result in a RTFM and the issue being closed.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
     public class AddINotifyPropertyChangedInterfaceAttribute : Attribute
     {
     }

--- a/TestAssemblies/AssemblyToProcess/StructWithNotify.cs
+++ b/TestAssemblies/AssemblyToProcess/StructWithNotify.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+public struct StructWithNotify : INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}
+
+public struct StructWithNotify<T> : INotifyPropertyChanged
+{
+    public T Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyToProcess/StructWithNotify.cs
+++ b/TestAssemblies/AssemblyToProcess/StructWithNotify.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using PropertyChanged;
 
 public struct StructWithNotify : INotifyPropertyChanged
 {
@@ -12,4 +13,16 @@ public struct StructWithNotify<T> : INotifyPropertyChanged
     public T Property1 { get; set; }
 
     public event PropertyChangedEventHandler PropertyChanged;
+}
+
+[AddINotifyPropertyChangedInterface]
+public struct StructWithNotifyAttribute
+{
+    public string Property1 { get; set; }
+}
+
+[AddINotifyPropertyChangedInterface]
+public struct StructWithNotifyAttribute<T>
+{
+    public T Property1 { get; set; }
 }

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -620,6 +620,20 @@ public class AssemblyToProcessTests
         EventTester.TestValueTypeProperty(instance);
     }
 
+    [Fact]
+    public void StructWithNotifyAttribute()
+    {
+        var instance = testResult.GetInstance("StructWithNotifyAttribute");
+        EventTester.TestValueTypeProperty(instance);
+    }
+
+    [Fact]
+    public void StructWithNotifyAttributeGeneric()
+    {
+        var instance = testResult.GetGenericInstance("StructWithNotifyAttribute`1", typeof(string));
+        EventTester.TestValueTypeProperty(instance);
+    }
+
     void DumpWarnings(string containingWord = null)
     {
         foreach (var warning in testResult.Warnings.Where(w => containingWord == null || w.Text.ContainsWholeWord(containingWord)))

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -606,10 +606,23 @@ public class AssemblyToProcessTests
         EventTester.TestProperty(instance, false);
     }
 
+    [Fact]
+    public void StructWithNotify()
+    {
+        var instance = testResult.GetInstance("StructWithNotify");
+        EventTester.TestValueTypeProperty(instance);
+    }
+
+    [Fact]
+    public void StructWithNotifyGeneric()
+    {
+        var instance = testResult.GetGenericInstance("StructWithNotify`1", typeof(string));
+        EventTester.TestValueTypeProperty(instance);
+    }
+
     void DumpWarnings(string containingWord = null)
     {
         foreach (var warning in testResult.Warnings.Where(w => containingWord == null || w.Text.ContainsWholeWord(containingWord)))
             outputHelper.WriteLine($"WARNING: {warning.Text}");
     }
-
 }

--- a/Tests/EventTester.cs
+++ b/Tests/EventTester.cs
@@ -87,6 +87,26 @@ public static class EventTester
         Assert.False(eventCalled);
     }
 
+    internal static void TestValueTypeProperty(dynamic instance)
+    {
+        var property1EventCalled = false;
+
+        instance.PropertyChanged += new PropertyChangedEventHandler((_, args) =>
+        {
+            if (args.PropertyName == "Property1")
+            {
+                property1EventCalled = true;
+            }
+        });
+
+        instance.Property1 = "a";
+        Assert.True(property1EventCalled);
+
+        property1EventCalled = false;
+        instance.Property1 = "a";
+        Assert.False(property1EventCalled);
+    }
+
     public static dynamic GetInstance(this Assembly assembly, string className, params object[] args)
     {
         var type = assembly.GetType(className, true);


### PR DESCRIPTION
This fixes the codegen for value types by boxing the instance where needed.

I also allowed `[AddINotifyPropertyChangedInterface]` on structs, as it seemed the right thing to do. Note that this case is always handled by the weaver. The source generator doesn't handle it since that generates [CS0282](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0282) and the user would need to disable it in their code.

Fixes #901
