### PR TITLE
Reference fixed Roslyn version

### DIFF
--- a/PropertyChanged.Fody.Analyzer.Tests/PropertyChanged.Fody.Analyzer.Tests.csproj
+++ b/PropertyChanged.Fody.Analyzer.Tests/PropertyChanged.Fody.Analyzer.Tests.csproj
@@ -12,13 +12,14 @@
     <PackageReference Include="AnalyzerTesting.CSharp.Extensions" Version="1.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" NoWarn="NU1608" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Verify.Xunit" Version="26.2.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
     <ProjectReference Include="..\PropertyChanged\PropertyChanged.csproj" />
-    <ProjectReference Include="..\PropertyChanged.Fody.Analyzer\PropertyChanged.Fody.Analyzer.csproj" />
+    <ProjectReference Include="..\PropertyChanged.Fody.Analyzer\PropertyChanged.Fody.Analyzer.csproj" NoWarn="NU1608" />
   </ItemGroup>
 
 </Project>

--- a/PropertyChanged.Fody.Analyzer/PropertyChanged.Fody.Analyzer.csproj
+++ b/PropertyChanged.Fody.Analyzer/PropertyChanged.Fody.Analyzer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.0.1]" PrivateAssets="all" />
     <PackageReference Include="Nullable.Extended.Analyzer" Version="1.10.4539" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This follows my remark from [here](https://github.com/Fody/PropertyChanged/pull/1052#discussion_r1566529798):

> Oh, I didn't notice this earlier, but I think the Microsoft.CodeAnalysis.CSharp package should be rolled back to v4.0.1 and frozen at that version unless there's a good reason to use a newer one, since referencing a newer version requires the user to have a .NET SDK or Visual Studio version which supports it. See [here](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md?rgh-link-date=2024-04-15T23%3A14%3A06Z) for the version map.
> 
> The problem is that it won't play along with tools which always suggest to bump the packages to the latest versions. 😞

So this ensures the analyzer supports older compilers, but runs tests with the latest one. Contrary to my previous remark, IDEs won't suggest updating `Microsoft.CodeAnalysis.CSharp`.

What do you think @tom-englert?
