### PR TITLE
Support OnlyAddINotifyPropertyChangedInterfaceAttribute option

### DIFF
--- a/PropertyChanged.Fody/Config/OnlyAddINotifyPropertyChangedInterfaceAttributeConfig.cs
+++ b/PropertyChanged.Fody/Config/OnlyAddINotifyPropertyChangedInterfaceAttributeConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool OnlyAddINotifyPropertyChangedInterfaceAttribute = false;
+
+    public void ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig()
+    {
+        var value = Config?.Attributes("OnlyAddINotifyPropertyChangedInterfaceAttribute")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            OnlyAddINotifyPropertyChangedInterfaceAttribute = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -13,6 +13,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         ResolveSuppressWarningsConfig();
         ResolveSuppressOnPropertyNameChangedWarningConfig();
         ResolveEventInvokerName();
+        ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
         FindCoreReferences();
         FindInterceptor();
         ProcessFilterTypeAttributes();

--- a/PropertyChanged.Fody/NotifyInterfaceFinder.cs
+++ b/PropertyChanged.Fody/NotifyInterfaceFinder.cs
@@ -35,7 +35,7 @@ public partial class ModuleWeaver
 
         foreach (var interfaceImplementation in typeDefinition.Interfaces)
         {
-            if (interfaceImplementation.InterfaceType.Name == "INotifyPropertyChanged")
+            if (interfaceImplementation.InterfaceType.Name == "INotifyPropertyChanged" && OnlyAddINotifyPropertyChangedInterfaceAttribute == false)
             {
                 typesImplementingINotify[fullName] = true;
                 return true;

--- a/PropertyChanged.Fody/PropertyChanged.Fody.xcf
+++ b/PropertyChanged.Fody/PropertyChanged.Fody.xcf
@@ -45,4 +45,9 @@
       <xs:documentation>Used to turn off build warnings about mismatched On_PropertyName_Changed methods.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="OnlyAddINotifyPropertyChangedInterfaceAttribute" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Used to turn on only classes that add AddINotifyQualityChangedInterfaceAttribute will be woven.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
 </xs:complexType>

--- a/SmokeTest/FodyWeavers.xsd
+++ b/SmokeTest/FodyWeavers.xsd
@@ -52,6 +52,11 @@
                 <xs:documentation>Used to turn off build warnings about mismatched On_PropertyName_Changed methods.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="OnlyAddINotifyPropertyChangedInterfaceAttribute" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to turn on only classes that add AddINotifyQualityChangedInterfaceAttribute will be woven.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/Tests/OnlyAddINotifyPropertyChangedInterfaceAttributeConfigTests.cs
+++ b/Tests/OnlyAddINotifyPropertyChangedInterfaceAttributeConfigTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Xml.Linq;
+
+public class OnlyAddINotifyPropertyChangedInterfaceAttributeConfigTests
+{
+    [Fact]
+    public void False()
+    {
+        var xElement = XElement.Parse("<PropertyChanged OnlyAddINotifyPropertyChangedInterfaceAttribute='false'/>");
+        var weaver = new ModuleWeaver { Config = xElement };
+        weaver.ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
+        Assert.False(weaver.OnlyAddINotifyPropertyChangedInterfaceAttribute);
+    }
+
+    [Fact]
+    public void False0()
+    {
+        var xElement = XElement.Parse("<PropertyChanged OnlyAddINotifyPropertyChangedInterfaceAttribute='0'/>");
+        var weaver = new ModuleWeaver { Config = xElement };
+        weaver.ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
+        Assert.False(weaver.OnlyAddINotifyPropertyChangedInterfaceAttribute);
+    }
+
+    [Fact]
+    public void True()
+    {
+        var xElement = XElement.Parse("<PropertyChanged OnlyAddINotifyPropertyChangedInterfaceAttribute='True'/>");
+        var weaver = new ModuleWeaver { Config = xElement };
+        weaver.ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
+        Assert.True(weaver.OnlyAddINotifyPropertyChangedInterfaceAttribute);
+    }
+
+    [Fact]
+    public void True1()
+    {
+        var xElement = XElement.Parse("<PropertyChanged OnlyAddINotifyPropertyChangedInterfaceAttribute='1'/>");
+        var weaver = new ModuleWeaver { Config = xElement };
+        weaver.ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
+        Assert.True(weaver.OnlyAddINotifyPropertyChangedInterfaceAttribute);
+    }
+
+    [Fact]
+    public void Default()
+    {
+        var weaver = new ModuleWeaver();
+        weaver.ResolveOnlyAddINotifyPropertyChangedInterfaceAttributeConfig();
+        Assert.False(weaver.OnlyAddINotifyPropertyChangedInterfaceAttribute);
+    }
+}


### PR DESCRIPTION
Where it is clear the below content has not read, the issue is likely to be closed with "please read the template". Please don't take offense at this. It is simply a time management decision. When someone raises an issue, without reading the template, then often too much time is spent going back and forth to obtain information that is outlined below.


#### You should already be a Patron

**It is expected that all developers using Fody either [become a Patron on OpenCollective](https://opencollective.com/fody/contribute/patron-3059), or have a [Tidelift Subscription](https://tidelift.com/subscription/pkg/nuget-fody?utm_source=nuget-fody&utm_medium=referral&utm_campaign=enterprise). [See Licensing/Patron FAQ](https://github.com/Fody/Home/blob/master/pages/licensing-patron-faq.md) for more information.** With that in mind, it is assumed anyone raising a PR is already a Patron. As such your GitHub Id may be verified against the [OpenCollective contributors](https://opencollective.com/fody#contributors). This process will depend on the PR quality, your circumstances, and the impact on the larger user base.


#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.


#### Description

Before PropertyChange.Fody was introduced in the old project, we had already implemented the IPropertyChanged interface ourselves. At that time, when we used PropertyChanged.Fody, it would also weave the old code. This was not the behavior I wanted. I wanted only the new classes that I had added the Attribute to to be woven.


#### The solution

Outline the implementation. Also include any alternative solutions considered.


#### Todos

 * [ ] Related issues
 * [ ] Tests
 * [ ] Documentation