### PR TITLE
Fix indexer detection logic to cover indexers with more than one parameter

### DIFF
--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -27,7 +27,7 @@ public partial class ModuleWeaver
         var propertyDefinition = propertyData.PropertyDefinition;
         var setMethod = propertyDefinition.SetMethod;
 
-        if (setMethod.Name == "set_Item" && setMethod.Parameters.Count == 2 && setMethod.Parameters[1].Name == "value")
+        if (setMethod.Name == "set_Item" && setMethod.Parameters.Count > 1 && setMethod.Parameters.Last().Name == "value")
         {
             return "Property is an indexer.";
         }

--- a/Tests/PropertyInfoCheckers/IndexerCheckerTest.cs
+++ b/Tests/PropertyInfoCheckers/IndexerCheckerTest.cs
@@ -7,16 +7,19 @@ public class IndexerCheckerTest
     public void IsIndexer()
     {
         var weaver = new ModuleWeaver();
-        var propertyDefinition = DefinitionFinder.FindType<IndexerClass>()
-            .Properties
-            .First();
+        var propertyDefinitions = DefinitionFinder.FindType<IndexerClass>()
+            .Properties;
 
-        var propertyData = new PropertyData
+        foreach (var propertyDefinition in propertyDefinitions)
         {
-            PropertyDefinition = propertyDefinition,
-        };
-        var message = weaver.CheckForWarning(propertyData, InvokerTypes.String);
-        Assert.Equal("Property is an indexer.", message);
+            var propertyData = new PropertyData
+            {
+                PropertyDefinition = propertyDefinition,
+            };
+
+            var message = weaver.CheckForWarning(propertyData, InvokerTypes.String);
+            Assert.Equal("Property is an indexer.", message);
+        }
     }
 
     public abstract class IndexerClass
@@ -24,6 +27,14 @@ public class IndexerCheckerTest
         public string this[string i]
         {
             get => null;
+            set
+            {
+            }
+        }
+
+        public double this[int x, int y, int z]
+        {
+            get => 0.0;
             set
             {
             }


### PR DESCRIPTION
might be nitpicking, just changes the warning from "Property takes more than one parameter" to "Property is an indexer" for indexers with more than one index parameter.